### PR TITLE
[Fix] KeyboardType Text로 변경 및 숫자와 쉼표, 공백만 입력받을 수 있도록 변경

### DIFF
--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/addrepeatcycle/AddRepeatCycleViewModel.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/addrepeatcycle/AddRepeatCycleViewModel.kt
@@ -29,7 +29,9 @@ class AddRepeatCycleViewModel @Inject constructor(
     }
 
     private fun onRepeatCycleChange(repeatCycle: String) {
-        setState { copy(intervals = repeatCycle) }
+        val allowed = repeatCycle.matches(Regex("^[0-9,\\s]*$"))
+
+        if (allowed) { setState { copy(intervals = repeatCycle) } }
     }
 
     private suspend fun saveRepeatCycle() {

--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/editrepeatcycle/EditRepeatCycleViewModel.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/editrepeatcycle/EditRepeatCycleViewModel.kt
@@ -48,7 +48,9 @@ class EditRepeatCycleViewModel @Inject constructor(
     }
 
     private fun onRepeatCycleChange(repeatCycle: String) {
-        setState { copy(intervals = repeatCycle) }
+        val allowed = repeatCycle.matches(Regex("^[0-9,\\s]*$"))
+
+        if (allowed) { setState { copy(intervals = repeatCycle) } }
     }
 
     private suspend fun updateRepeatCycle() {

--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/ui/RepeatCycleContent.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/ui/RepeatCycleContent.kt
@@ -31,7 +31,7 @@ internal fun RepeatCycleContent(
     EbbingTextInputDefault(
         value = repeatCycle,
         hint = "어떤 주기로 일정을 반복할까요?",
-        keyboardType = KeyboardType.Number,
+        keyboardType = KeyboardType.Text,
         onValueChange = onRepeatCycleChange,
         limit = 60,
         rightComponent = {


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- **KeyboardType Text로 변경 및 숫자와 쉼표, 공백만 입력받을 수 있도록 변경**

## 2. 🖼️ 스크린샷(선택)
<img width="520" alt="image" src="https://github.com/user-attachments/assets/e22548f3-8012-48bd-bb4c-edc16107911b" />

## 3. 새롭게 알게된 점
- 에뮬레이터 상으로는 `KeyboardType.Number` 로 했을 때 쉼표가 잘 나타났지만, 구글 키보드 이외의 갤럭시 키보드와 같이 일부 키보드에서는 쉼표가 보장되지 않는다고 한다. 