### PR TITLE
[Fix] 일정이 많을 때 Pager로 스와이프해서 날을 넘겼을 때 스크롤이 안되던 버그 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
     namespace = "com.tgyuu.ebbingplanner"
 
     defaultConfig {
-        versionCode = 19
-        versionName = "1.0.18"
+        versionCode = 20
+        versionName = "1.0.19"
         targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
@@ -90,7 +90,6 @@ class MainActivity : ComponentActivity() {
             val theme by viewModel.theme.collectAsStateWithLifecycle()
 
             val scope = rememberCoroutineScope()
-
             val navController = rememberNavController()
             val bottomSheetState = rememberEbbingBottomSheetState()
             val snackBarHostState = remember { SnackbarHostState() }
@@ -127,8 +126,6 @@ class MainActivity : ComponentActivity() {
                             },
                         )
                     }
-
-                    TrackNavigationDestination(navController)
 
                     HandleSideEffects(
                         navController = navController,

--- a/app/src/main/java/com/tgyuu/ebbingplanner/ui/AppState.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/ui/AppState.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.tgyuu.analytics.TrackNavigationDestination
 import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetState
 import com.tgyuu.navigation.Route
 import com.tgyuu.navigation.SettingGraph
@@ -19,6 +20,8 @@ fun rememberEbbingAppState(
     networkMonitor: NetworkMonitor,
     bottomSheetState: EbbingBottomSheetState,
 ): EbbingAppState {
+    TrackNavigationDestination(navController)
+
     return remember(
         navController,
         networkMonitor,
@@ -53,9 +56,7 @@ class EbbingAppState(
     val requireNetworkConnection: Boolean
         @Composable get() = currentDestination?.hierarchy?.any { d ->
             AppUiPolicy.networkRequiredRoutes.any {
-                d.route?.startsWith(
-                    it.qualifiedName ?: ""
-                ) == true
+                d.route?.startsWith(it.qualifiedName ?: "") == true
             }
         } ?: false
 

--- a/core/analytics/src/main/java/com/tgyuu/analytics/AnalyticsHelper.kt
+++ b/core/analytics/src/main/java/com/tgyuu/analytics/AnalyticsHelper.kt
@@ -36,8 +36,8 @@ fun TrackNavigationDestination(navController: NavHostController) {
 
             analyticsHelper.logEvent(
                 AnalyticsEvent(
-                    type = AnalyticsEvent.Types.SCREEN_VIEW,
-                    properties = mutableMapOf(AnalyticsEvent.PropertiesKeys.SCREEN_NAME to screenName)
+                    type = SCREEN_VIEW,
+                    properties = mutableMapOf(SCREEN_NAME to screenName)
                 )
             )
         }

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
@@ -12,10 +12,10 @@ import java.time.LocalDateTime
 
 @Dao
 interface TodoWithSchedulesDao {
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertInfo(entity: TodoInfoEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSchedules(schedules: List<TodoScheduleEntity>)
 
     @Transaction

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -353,7 +353,6 @@ private fun PhoneHomeScreen(
                 }
             } else {
                 EbbingTodoList(
-                    listState = listState,
                     sortType = state.sortType,
                     selectedDate = selectedDate,
                     todoLists = state.schedulesByDateMap[selectedDate] ?: emptyList(),
@@ -391,7 +390,6 @@ private fun TabletHomeScreen(
     modifier: Modifier = Modifier
 ) {
     val scope = rememberCoroutineScope()
-    val listState = rememberLazyListState()
     var selectedDate by remember(workedDate) { mutableStateOf(workedDate) }
     val calendarState = rememberCalendarState()
 
@@ -411,7 +409,6 @@ private fun TabletHomeScreen(
                 if (selectedDate != it) {
                     scope.launch {
                         selectedDate = it
-                        listState.animateScrollToItem(0)
                     }
                 }
             },
@@ -436,7 +433,6 @@ private fun TabletHomeScreen(
             }
         } else {
             EbbingTodoList(
-                listState = listState,
                 sortType = state.sortType,
                 selectedDate = selectedDate,
                 todoLists = state.schedulesByDateMap[selectedDate] ?: emptyList(),
@@ -446,7 +442,6 @@ private fun TabletHomeScreen(
                         scope.launch {
                             selectedDate = it
                             calendarState.onDateSelect(it)
-                            listState.animateScrollToItem(0)
                         }
                     }
                 },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,7 +42,6 @@ import java.time.LocalDate
 
 @Composable
 internal fun EbbingTodoList(
-    listState: LazyListState,
     sortType: SortType,
     selectedDate: LocalDate,
     todoLists: List<TodoSchedule>,
@@ -87,7 +86,6 @@ internal fun EbbingTodoList(
                 date = selectedDate,
                 todos = todoLists,
                 schedulesByTodoInfo = schedulesByTodoInfo,
-                listState = listState,
                 onCheckedChange = onCheckedChange,
                 onEdit = onEditScheduleClick
             )
@@ -156,10 +154,11 @@ private fun TodoPage(
     date: LocalDate,
     todos: List<TodoSchedule>,
     schedulesByTodoInfo: Map<Int, List<TodoSchedule>>,
-    listState: LazyListState,
     onCheckedChange: (TodoSchedule) -> Unit,
     onEdit: (TodoSchedule) -> Unit
 ) {
+    val listState = rememberLazyListState()
+
     if (todos.isNotEmpty()) {
         LazyColumn(
             state = listState,


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- **일정이 많을 때 Pager로 스와이프해서 날을 넘겼을 때 스크롤이 안되던 버그 수정**

- ListState를 하나로 공유하는 구조였는데, 만약 이전날짜의 scroll Offset이 너무 많을 경우 날을 넘겼을 때, 해당 Offset이 너무 커서 스크롤이 이상하게 동작하던 버그가 있었음. 각 Pager 내부에 ListState를 관리하도록 변경

## 2. 🖼️ 스크린샷(선택)
<img width="1001" height="337" alt="image" src="https://github.com/user-attachments/assets/8dd2fbfb-f262-4de2-afba-b4d00cf44a16" />

### 기존

https://github.com/user-attachments/assets/6ecb5529-5fcf-4432-a48d-da945ed12241

### 수정

https://github.com/user-attachments/assets/21c2f5de-9741-4aac-bf95-c0613b1ef28f


