### PR TITLE
[Refactor] : KMP를 위해 javaDate를 kotlinxDate로 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,5 +86,6 @@ dependencies {
     implementation(libs.androidx.glance.material3)
     implementation(libs.androidx.glance.preview)
     implementation(libs.androidx.glance.appwidget.preview)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.gson)
 }

--- a/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
@@ -23,9 +23,9 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.tgyuu.analytics.AnalyticsHelper
 import com.tgyuu.analytics.LocalAnalyticsHelper
-import com.tgyuu.analytics.TrackNavigationDestination
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.toFormattedString
 import com.tgyuu.common.util.LocalAnimationsEnabled
 import com.tgyuu.common.util.MemoryAnimationController
@@ -52,7 +52,7 @@ import com.tgyuu.setting.BuildConfig
 import com.tgyuu.sync.network.NetworkMonitor
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/tgyuu/ebbingplanner/alarm/NotificationHelperImpl.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/alarm/NotificationHelperImpl.kt
@@ -11,7 +11,7 @@ import com.tgyuu.alarm.NotificationHelper
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.ebbingplanner.MainActivity
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 class NotificationHelperImpl @Inject constructor(

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -43,6 +43,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
 import com.google.gson.reflect.TypeToken
+import com.tgyuu.common.now
 import com.tgyuu.designsystem.component.calendar.CalendarDate
 import com.tgyuu.designsystem.component.calendar.EbbingDayOfWeek
 import com.tgyuu.designsystem.component.calendar.getCalendarDates
@@ -63,7 +64,8 @@ import com.tgyuu.ebbingplanner.widget.util.SelectDateAction
 import com.tgyuu.ebbingplanner.widget.util.SelectDateAction.Companion.SELECTED_DATE
 import com.tgyuu.ebbingplanner.widget.util.destinationKey
 import com.tgyuu.ebbingplanner.widget.util.selectedDateKey
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 class CalendarWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
@@ -159,7 +161,7 @@ private fun CalendarWidgetHeader() {
             Spacer(modifier = GlanceModifier.size(20.dp))
 
             Text(
-                text = "${today.year}년 ${today.monthValue}월",
+                text = "${today.year}년 ${today.month.number}월",
                 style = TextStyle(
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Bold,
@@ -317,7 +319,7 @@ private fun ColumnScope.SelectedDateTodoList(
         ) {
             Text(
                 text = if (selectedDate == LocalDate.now()) "오늘 할 일   "
-                else "${selectedDate.monthValue}월 ${selectedDate.dayOfMonth}일 할 일   ",
+                else "${selectedDate.month.number}월 ${selectedDate.dayOfMonth}일 할 일   ",
                 style = TextStyle(
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -9,6 +9,9 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.tgyuu.common.copy
+import com.tgyuu.common.now
+import com.tgyuu.designsystem.component.calendar.totalDaysInMonth
 import com.tgyuu.domain.model.SortType
 import com.tgyuu.domain.model.Theme
 import com.tgyuu.domain.model.TodoSchedule
@@ -25,7 +28,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -77,8 +80,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
 
         val now = LocalDate.now()
         val allSchedules = todoRepository.loadTodoSchedulesByDateRange(
-            now.withDayOfMonth(1),
-            now.withDayOfMonth(now.lengthOfMonth())
+            now.copy(day = 1),
+            now.copy(now.totalDaysInMonth())
         )
         val byDate = buildByDateMap(allSchedules, sortType)
 

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -57,7 +57,7 @@ import com.tgyuu.ebbingplanner.widget.util.EbbingWidgetPreview
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
 import com.tgyuu.ebbingplanner.widget.util.destinationKey
 import com.tgyuu.ebbingplanner.widget.util.todoIdKey
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 class TodayTodoWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
@@ -273,12 +273,12 @@ private fun HomeWidgetPreview2() {
                     tagId = 1,
                     name = "공부",
                     color = 0xFF3282B8.toInt(),
-                    date = LocalDate.of(2025, 5, 8),
+                    date = LocalDate(2025, 5, 8),
                     memo = "Jetpack Compose 위젯",
                     priority = 1,
                     isDone = false,
-                    createdAt = LocalDate.of(2025, 5, 1),
-                    infoCreatedAt = LocalDate.of(2025, 5, 1)
+                    createdAt = LocalDate(2025, 5, 1),
+                    infoCreatedAt = LocalDate(2025, 5, 1)
                 ),
                 TodoSchedule(
                     id = 2,
@@ -287,12 +287,12 @@ private fun HomeWidgetPreview2() {
                     tagId = 2,
                     name = "운동",
                     color = 0xFFFF7490.toInt(),
-                    date = LocalDate.of(2025, 5, 8),
+                    date = LocalDate(2025, 5, 8),
                     memo = "헬스장 1시간",
                     priority = 2,
                     isDone = true,
-                    createdAt = LocalDate.of(2025, 5, 2),
-                    infoCreatedAt = LocalDate.of(2025, 5, 2)
+                    createdAt = LocalDate(2025, 5, 2),
+                    infoCreatedAt = LocalDate(2025, 5, 2)
                 )
             )
         )

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -9,6 +9,7 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.Theme
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.TodoRepository
@@ -23,7 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/core/alarm/build.gradle.kts
+++ b/core/alarm/build.gradle.kts
@@ -19,4 +19,6 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/alarm/src/main/java/com/tgyuu/alarm/AlarmScheduler.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/AlarmScheduler.kt
@@ -9,7 +9,7 @@ import android.os.Build
 import android.provider.Settings
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/core/alarm/src/main/java/com/tgyuu/alarm/NotificationHelper.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/NotificationHelper.kt
@@ -4,7 +4,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import com.tgyuu.domain.model.TodoSchedule
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 abstract class NotificationHelper() {
     fun createNotificationChannel(context: Context) {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 
 dependencies {
     implementation(libs.coroutines.core)
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/common/src/main/java/com/tgyuu/common/DateUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/DateUtil.kt
@@ -1,37 +1,85 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.tgyuu.common
 
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.temporal.ChronoUnit
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import kotlin.math.absoluteValue
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
-private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-private val dateTimeFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+/**
+ * 현재 시스템 날짜/시간 가져오기
+ */
+fun LocalDate.Companion.now(): LocalDate =
+    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
 
+fun LocalDateTime.Companion.now(): LocalDateTime =
+    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+
+fun LocalDate.copy(
+    year: Int = this.year,
+    month: Int = this.month.number,
+    day: Int = this.day,
+): LocalDate = LocalDate(year, month, day)
+
+fun LocalDateTime.copy(
+    year: Int = this.year,
+    month: Int = this.month.number,
+    day: Int = this.day,
+    hour: Int = this.hour,
+    minute: Int = this.minute,
+    second: Int = this.second,
+    nanoSecond: Int = this.nanosecond,
+): LocalDateTime = LocalDateTime(year, month, day, hour, minute, second, nanoSecond)
+
+
+/**
+ * yyyy-MM-dd 형식 문자열로 변환
+ */
 fun LocalDate.toFormattedString(): String {
-    return this.format(dateFormatter)
+    return "${year.toString().padStart(4, '0')}-${
+        month.number.toString().padStart(2, '0')
+    }-${day.toString().padStart(2, '0')}"
 }
 
+/**
+ * 문자열 -> LocalDate 변환
+ */
 fun String.toLocalDateOrThrow(): LocalDate {
     return try {
-        LocalDate.parse(this, dateFormatter)
-    } catch (e: DateTimeParseException) {
+        LocalDate.parse(this)
+    } catch (e: Exception) {
         throw IllegalArgumentException("날짜 형식이 올바르지 않습니다: $this", e)
     }
 }
 
+/**
+ * yyyy-MM-dd HH:mm:ss 형식 문자열로 변환
+ */
 fun LocalDateTime.toFormattedString(): String {
-    return this.format(dateTimeFormatter)
+    return "${year.toString().padStart(4, '0')}-${
+        month.number.toString().padStart(2, '0')
+    }-${day.toString().padStart(2, '0')} " +
+            "${hour.toString().padStart(2, '0')}:${
+                minute.toString().padStart(2, '0')
+            }:${second.toString().padStart(2, '0')}"
 }
 
+/**
+ * 문자열 -> LocalDateTime 변환
+ */
 fun String.toLocalDateTimeOrThrow(): LocalDateTime {
     return try {
-        LocalDateTime.parse(this, dateTimeFormatter)  // 공백 포맷
-    } catch (e: DateTimeParseException) {
-        LocalDateTime.parse(this, DateTimeFormatter.ISO_LOCAL_DATE_TIME)  // T 포맷
+        LocalDateTime.parse(this)
+    } catch (e: Exception) {
+        throw IllegalArgumentException("날짜 시간 형식이 올바르지 않습니다: $this", e)
     }
 }
 
@@ -40,18 +88,24 @@ fun String.toLocalDateTimeOrThrow(): LocalDateTime {
  * 같으면 "오늘", 미래면 "N일 후", 과거면 "N일 전"을 반환
  */
 fun LocalDate.toRelativeDayDescription(referenceDate: LocalDate = LocalDate.now()): String {
-    val diff = daysBetween(referenceDate, this)
+    val diff = this.daysUntil(referenceDate)
     return when {
-        diff == 0L -> "오늘"
-        diff > 0L -> "${diff}일 후"
-        else -> "${-diff}일 전"
+        diff == 0 -> "오늘"
+        diff > 0 -> "${diff}일 후"
+        else -> "${diff.absoluteValue}일 전"
     }
 }
 
-private fun daysBetween(start: LocalDate, end: LocalDate): Long {
-    return ChronoUnit.DAYS.between(start, end)
+/**
+ * 두 날짜 사이 일수 계산
+ */
+fun LocalDate.daysUntil(other: LocalDate): Int {
+    return (other.toEpochDays() - this.toEpochDays()).toInt()
 }
 
+/**
+ * 스케줄 생성
+ */
 fun generateValidSchedules(
     baseDate: LocalDate,
     intervals: List<Int>,
@@ -59,21 +113,22 @@ fun generateValidSchedules(
 ): List<LocalDate> {
     val usedDates = mutableSetOf<LocalDate>()
     return intervals.map { interval ->
-        var candidate = baseDate.plusDays(interval.toLong()).nextValidDate(restDays)
-
+        var candidate = baseDate.plus(interval, DateTimeUnit.DAY).nextValidDate(restDays)
         while (candidate in usedDates) {
-            candidate = candidate.plusDays(1).nextValidDate(restDays)
+            candidate = candidate.plus(1, DateTimeUnit.DAY).nextValidDate(restDays)
         }
-
         usedDates += candidate
         candidate
     }
 }
 
+/**
+ * 휴일 제외 다음 유효한 날짜 계산
+ */
 private fun LocalDate.nextValidDate(restDays: Set<DayOfWeek>): LocalDate {
     var date = this
     while (date.dayOfWeek in restDays) {
-        date = date.plusDays(1)
+        date = date.plus(1, DateTimeUnit.DAY)
     }
     return date
 }

--- a/core/common/src/test/java/com/tgyuu/common/DateUtilTest.kt
+++ b/core/common/src/test/java/com/tgyuu/common/DateUtilTest.kt
@@ -1,21 +1,20 @@
 package com.tgyuu.common
 
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeParseException
 
 class LocalDateFormatTest {
 
     @Test
     fun `LocalDate를 문자열로 변환할 수 있다`() {
         // given
-        val date = LocalDate.of(2025, 4, 22)
+        val date = LocalDate(2025, 4, 22)
 
         // when
         val result = date.toFormattedString()
@@ -33,7 +32,7 @@ class LocalDateFormatTest {
         val result = input.toLocalDateOrThrow()
 
         // then
-        assertEquals(LocalDate.of(2023, 11, 15), result)
+        assertEquals(LocalDate(2023, 11, 15), result)
     }
 
     @ParameterizedTest
@@ -60,7 +59,7 @@ class LocalDateFormatTest {
     @Test
     fun `LocalDateTime을 문자열로 변환할 수 있다`() {
         // given
-        val dateTime = LocalDateTime.of(2025, 4, 22, 15, 30, 45)
+        val dateTime = LocalDateTime(2025, 4, 22, 15, 30, 45)
 
         // when
         val result = dateTime.toFormattedString()
@@ -78,7 +77,7 @@ class LocalDateFormatTest {
         val result = input.toLocalDateTimeOrThrow()
 
         // then
-        assertEquals(LocalDateTime.of(2023, 11, 15, 9, 5, 0), result)
+        assertEquals(LocalDateTime(2023, 11, 15, 9, 5, 0), result)
     }
 
     @ParameterizedTest
@@ -97,11 +96,11 @@ class LocalDateFormatTest {
             "2023-12-31 23:60:00"  // 60분은 허용 안 됨
         ]
     )
-    fun `잘못된 형식의 문자열을 LocalDateTime으로 변환하려고 하면 DateTimeParseException이 발생한다`(
+    fun `잘못된 형식의 문자열을 LocalDateTime으로 변환하려고 하면 IllegalArgumentException이 발생한다`(
         input: String
     ) {
         // expect
-        assertThrows<DateTimeParseException> {
+        assertThrows<IllegalArgumentException> {
             input.toLocalDateTimeOrThrow()
         }
     }
@@ -109,7 +108,7 @@ class LocalDateFormatTest {
     @Test
     fun `같은 날짜를 비교하면 오늘을 반환한다`() {
         // given
-        val reference = LocalDate.of(2025, 4, 23)
+        val reference = LocalDate(2025, 4, 23)
 
         // when
         val result = reference.toRelativeDayDescription(referenceDate = reference)
@@ -121,8 +120,8 @@ class LocalDateFormatTest {
     @Test
     fun `미래 날짜를 비교하면 N일 후를 반환한다`() {
         // given
-        val reference = LocalDate.of(2025, 4, 20)
-        val futureDate = LocalDate.of(2025, 4, 25)
+        val reference = LocalDate(2025, 4, 20)
+        val futureDate = LocalDate(2025, 4, 25)
 
         // when
         val result = futureDate.toRelativeDayDescription(referenceDate = reference)
@@ -134,8 +133,8 @@ class LocalDateFormatTest {
     @Test
     fun `과거 날짜를 비교하면 N일 전을 반환한다`() {
         // given
-        val reference = LocalDate.of(2025, 4, 25)
-        val pastDate = LocalDate.of(2025, 4, 20)
+        val reference = LocalDate(2025, 4, 25)
+        val pastDate = LocalDate(2025, 4, 20)
 
         // when
         val result = pastDate.toRelativeDayDescription(referenceDate = reference)
@@ -147,7 +146,7 @@ class LocalDateFormatTest {
     @Test
     fun `휴일이 없는 경우 그대로 반복 주기를 적용한다`() {
         // given
-        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val baseDate = LocalDate(2025, 7, 20) // 일요일
         val intervals = listOf(0, 1, 2)
         val restDays = emptySet<DayOfWeek>()
 
@@ -157,9 +156,9 @@ class LocalDateFormatTest {
         // then
         assertEquals(
             listOf(
-                LocalDate.of(2025, 7, 20),
-                LocalDate.of(2025, 7, 21),
-                LocalDate.of(2025, 7, 22),
+                LocalDate(2025, 7, 20),
+                LocalDate(2025, 7, 21),
+                LocalDate(2025, 7, 22),
             ),
             result
         )
@@ -168,7 +167,7 @@ class LocalDateFormatTest {
     @Test
     fun `휴일이면 반복 주기를 계산할 때 다음 평일로 이동한다`() {
         // given
-        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val baseDate = LocalDate(2025, 7, 20) // 일요일
         val intervals = listOf(0, 1, 2)
         val restDays = setOf(DayOfWeek.SUNDAY)
 
@@ -178,9 +177,9 @@ class LocalDateFormatTest {
         // then
         assertEquals(
             listOf(
-                LocalDate.of(2025, 7, 21), // 7/20은 일요일이라서 → 7/21
-                LocalDate.of(2025, 7, 22),
-                LocalDate.of(2025, 7, 23),
+                LocalDate(2025, 7, 21), // 7/20은 일요일이라서 → 7/21
+                LocalDate(2025, 7, 22),
+                LocalDate(2025, 7, 23),
             ),
             result
         )
@@ -189,7 +188,7 @@ class LocalDateFormatTest {
     @Test
     fun `중복된 날짜가 있을 경우, 반복 주기를 구할 때 다음 날짜를 선택한다`() {
         // given
-        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val baseDate = LocalDate(2025, 7, 20) // 일요일
         val intervals = listOf(0, 0, 0)
         val restDays = emptySet<DayOfWeek>()
 
@@ -199,9 +198,9 @@ class LocalDateFormatTest {
         // then
         assertEquals(
             listOf(
-                LocalDate.of(2025, 7, 20),
-                LocalDate.of(2025, 7, 21),
-                LocalDate.of(2025, 7, 22)
+                LocalDate(2025, 7, 20),
+                LocalDate(2025, 7, 21),
+                LocalDate(2025, 7, 22)
             ),
             result
         )
@@ -210,7 +209,7 @@ class LocalDateFormatTest {
     @Test
     fun `반복 주기를 구할 때 중복 방지와 휴일 회피가 동시에 작동한다`() {
         // given
-        val baseDate = LocalDate.of(2025, 7, 19) // 토요일
+        val baseDate = LocalDate(2025, 7, 19) // 토요일
         val intervals = listOf(0, 0, 0)
         val restDays = setOf(DayOfWeek.SUNDAY)
 
@@ -220,9 +219,9 @@ class LocalDateFormatTest {
         // then
         assertEquals(
             listOf(
-                LocalDate.of(2025, 7, 19), // 7/19 (토)
-                LocalDate.of(2025, 7, 21), // 7/20 (일) → skip → 7/21
-                LocalDate.of(2025, 7, 22)  // 중복 회피 → 7/22
+                LocalDate(2025, 7, 19), // 7/19 (토)
+                LocalDate(2025, 7, 21), // 7/20 (일) → skip → 7/21
+                LocalDate(2025, 7, 22)  // 중복 회피 → 7/22
             ),
             result
         )

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
     implementation(projects.core.database)
     implementation(projects.core.datastore)
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.tgyuu.data.repository
 
-import android.util.Log
+import com.tgyuu.common.now
 import com.tgyuu.database.source.repeatcycle.LocalRepeatCycleDataSource
 import com.tgyuu.database.source.sync.LocalSyncTransactionDataSource
 import com.tgyuu.database.source.tag.LocalTagDataSource
@@ -16,12 +16,12 @@ import com.tgyuu.network.defaultDate
 import com.tgyuu.network.source.SyncDataSource
 import com.tgyuu.network.toDate
 import com.tgyuu.network.toLocalDateTime
-import com.tgyuu.network.toZonedDateTimeOrNull
+import com.tgyuu.network.toLocalDateTimeOrNull
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 
 class SyncRepositoryImpl @Inject constructor(
@@ -35,7 +35,7 @@ class SyncRepositoryImpl @Inject constructor(
     override suspend fun ensureUUIDExists() = localSyncDataSource.ensureUUIDExists()
     override suspend fun getUuid(): String = localSyncDataSource.uuid.first()
     override suspend fun getConnectedUuid(): String? = localSyncDataSource.connectedUuid.first()
-    override suspend fun getServerLastUpdatedAt(): ZonedDateTime? = coroutineScope {
+    override suspend fun getServerLastUpdatedAt(): LocalDateTime? = coroutineScope {
         val uuidDeferred = async { getUuid() }
         val connectedUuidDeferred = async { getConnectedUuid() }
 
@@ -46,15 +46,15 @@ class SyncRepositoryImpl @Inject constructor(
             .toDomain()
     }
 
-    override suspend fun getLocalSyncedAt(): ZonedDateTime? =
+    override suspend fun getLocalSyncedAt(): LocalDateTime? =
         localSyncDataSource.lastSyncTime.first()
 
-    override suspend fun syncUpData(): ZonedDateTime {
+    override suspend fun syncUpData(): LocalDateTime {
         downloadData()
         return uploadData()
     }
 
-    override suspend fun generateConnectCode(connectCode: String): ZonedDateTime =
+    override suspend fun generateConnectCode(connectCode: String): LocalDateTime =
         coroutineScope {
             val response = syncDataSource.generateConnectCode(
                 uuid = getUuid(),
@@ -74,10 +74,10 @@ class SyncRepositoryImpl @Inject constructor(
         }
 
     override suspend fun getMyConnectCode(): String? = localSyncDataSource.connectCode.first()
-    override suspend fun getConnectCodeExpiration(): ZonedDateTime? {
+    override suspend fun getConnectCodeExpiration(): LocalDateTime? {
         val expiration = localSyncDataSource.connectCodeExpirationTime.first() ?: return null
-        val now = ZonedDateTime.now()
-        if (expiration.isAfter(now)) return expiration
+        val now = LocalDateTime.now()
+        if (expiration > now) return expiration
 
         // 만료된 시간이라면 저장된 데이터를 비워줌
         localSyncDataSource.setConnectCodeExpirationTime(null)
@@ -106,7 +106,7 @@ class SyncRepositoryImpl @Inject constructor(
         localSyncDataSource.setLastSyncTime(null)
     }
 
-    private suspend fun uploadData(): ZonedDateTime = coroutineScope {
+    private suspend fun uploadData(): LocalDateTime = coroutineScope {
         val uuidDeferred = async { getUuid() }
         val linkedUuidDeferred = async { getConnectedUuid() }
 
@@ -146,9 +146,7 @@ class SyncRepositoryImpl @Inject constructor(
         val connectedUuid = connectedUuidDeferred.await()
 
         val lastSyncTime = localSyncDataSource.lastSyncTime
-            .first()
-            ?.toLocalDateTime()
-            ?.toDate() ?: defaultDate
+            .first()?.toDate() ?: defaultDate
 
         val response = syncDataSource.downloadData(connectedUuid ?: uuid, lastSyncTime)
             .getOrThrow()
@@ -237,34 +235,32 @@ class SyncRepositoryImpl @Inject constructor(
     }
 
     private suspend fun loadSchedulesForSync(): List<TodoScheduleForSync> {
-        val lastSyncTime = localSyncDataSource.lastSyncTime.first()
-            ?.toLocalDateTime() ?: defaultDate.toLocalDateTime()
+        val lastSyncTime = localSyncDataSource.lastSyncTime.first() ?: defaultDate.toLocalDateTime()
 
         return localTodoDataSource.getSchedulesForSync(lastSyncTime)
     }
 
     private suspend fun loadTagsForSync(): List<TodoTagForSync> {
         val lastSyncTime = localSyncDataSource.lastSyncTime.first()
-            ?.toLocalDateTime() ?: defaultDate.toLocalDateTime()
+            ?: defaultDate.toLocalDateTime()
 
         return localTagDataSource.getTagsForSync(lastSyncTime)
     }
 
     private suspend fun loadRepeatCyclesForSync(): List<RepeatCycleForSync> {
-        val lastSyncTime = localSyncDataSource.lastSyncTime.first()
-            ?.toLocalDateTime() ?: defaultDate.toLocalDateTime()
+        val lastSyncTime = localSyncDataSource.lastSyncTime.first() ?: defaultDate.toLocalDateTime()
 
         return localRepeatCycleDataSource.getRepeatCyclesForSync(lastSyncTime)
     }
 
     private suspend fun loadTodoInfosForSync(): List<TodoInfoForSync> {
         val lastSyncTime = localSyncDataSource.lastSyncTime.first()
-            ?.toLocalDateTime() ?: defaultDate.toLocalDateTime()
+            ?: defaultDate.toLocalDateTime()
 
         return localTodoDataSource.getTodoInfosForSync(lastSyncTime)
     }
 
-    private suspend fun replaceData(): ZonedDateTime? = coroutineScope {
+    private suspend fun replaceData(): LocalDateTime? = coroutineScope {
         val uuidDeferred = async { getUuid() }
         val connectedUuidDeferred = async { getConnectedUuid() }
 
@@ -273,7 +269,6 @@ class SyncRepositoryImpl @Inject constructor(
 
         val lastSyncTime = localSyncDataSource.lastSyncTime
             .first()
-            ?.toLocalDateTime()
             ?.toDate() ?: defaultDate
 
         val response = syncDataSource.downloadData(connectedUuid ?: uuid, lastSyncTime)
@@ -291,7 +286,7 @@ class SyncRepositoryImpl @Inject constructor(
             schedules = schedules
         )
 
-        val syncedAt = response.syncedAt.toZonedDateTimeOrNull()
+        val syncedAt = response.syncedAt.toLocalDateTimeOrNull()
         localSyncDataSource.setLastSyncTime(syncedAt)
         syncedAt
     }

--- a/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
@@ -14,7 +14,7 @@ import com.tgyuu.domain.repository.TodoRepository
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 class TodoRepositoryImpl @Inject constructor(

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -20,5 +20,6 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
+    implementation(libs.kotlinx.datetime)
     androidTestImplementation(libs.androidx.room.testing)
 }

--- a/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
+++ b/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
@@ -4,8 +4,8 @@ import androidx.room.TypeConverter
 import com.tgyuu.common.toFormattedString
 import com.tgyuu.common.toLocalDateOrThrow
 import com.tgyuu.common.toLocalDateTimeOrThrow
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 class EbbingConverters {
     // --- LocalDate ---

--- a/core/database/src/main/java/com/tgyuu/database/dao/RepeatCyclesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/RepeatCyclesDao.kt
@@ -5,8 +5,9 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.tgyuu.common.now
 import com.tgyuu.database.model.RepeatCycleEntity
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 @Dao
 interface RepeatCyclesDao {

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoSchedulesDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.tgyuu.common.now
 import com.tgyuu.database.model.TodoInfoEntity
 import com.tgyuu.database.model.TodoScheduleEntity
 import com.tgyuu.domain.model.TodoInfo
@@ -12,8 +13,8 @@ import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 @Dao
 interface TodoSchedulesDao {

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoTagsDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoTagsDao.kt
@@ -6,9 +6,10 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import com.tgyuu.common.now
 import com.tgyuu.database.model.TodoTagEntity
 import com.tgyuu.domain.model.sync.TodoTagForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 @Dao
 interface TodoTagsDao {

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
@@ -5,10 +5,11 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import com.tgyuu.common.now
 import com.tgyuu.database.model.TodoInfoEntity
 import com.tgyuu.database.model.TodoScheduleEntity
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 @Dao
 interface TodoWithSchedulesDao {

--- a/core/database/src/main/java/com/tgyuu/database/model/RepeatCycleEntity.kt
+++ b/core/database/src/main/java/com/tgyuu/database/model/RepeatCycleEntity.kt
@@ -2,9 +2,10 @@ package com.tgyuu.database.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 @Entity(tableName = "repeat_cycle")
 data class RepeatCycleEntity(

--- a/core/database/src/main/java/com/tgyuu/database/model/TodoInfoEntity.kt
+++ b/core/database/src/main/java/com/tgyuu/database/model/TodoInfoEntity.kt
@@ -4,10 +4,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import com.tgyuu.domain.model.TodoSchedule
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.sync.TodoInfoForSync
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 @Entity(
     tableName = "todo_info",

--- a/core/database/src/main/java/com/tgyuu/database/model/TodoScheduleEntity.kt
+++ b/core/database/src/main/java/com/tgyuu/database/model/TodoScheduleEntity.kt
@@ -4,10 +4,11 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 @Entity(
     tableName = "schedule",

--- a/core/database/src/main/java/com/tgyuu/database/model/TodoTagEntity.kt
+++ b/core/database/src/main/java/com/tgyuu/database/model/TodoTagEntity.kt
@@ -2,10 +2,11 @@ package com.tgyuu.database.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.domain.model.sync.TodoTagForSync
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 @Entity(tableName = "todo_tag")
 data class TodoTagEntity(

--- a/core/database/src/main/java/com/tgyuu/database/source/repeatcycle/LocalRepeatCycleDataSource.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/repeatcycle/LocalRepeatCycleDataSource.kt
@@ -3,7 +3,7 @@ package com.tgyuu.database.source.repeatcycle
 import com.tgyuu.database.model.RepeatCycleEntity
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 interface LocalRepeatCycleDataSource {
     suspend fun insertRepeatCycle(intervals: List<Int>): Long

--- a/core/database/src/main/java/com/tgyuu/database/source/repeatcycle/LocalRepeatCycleDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/repeatcycle/LocalRepeatCycleDataSourceImpl.kt
@@ -6,7 +6,7 @@ import com.tgyuu.database.model.RepeatCycleEntity
 import com.tgyuu.database.model.toEntity
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 
 class LocalRepeatCycleDataSourceImpl @Inject constructor(

--- a/core/database/src/main/java/com/tgyuu/database/source/tag/LocalTagDataSource.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/tag/LocalTagDataSource.kt
@@ -3,7 +3,7 @@ package com.tgyuu.database.source.tag
 import com.tgyuu.database.model.TodoTagEntity
 import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.domain.model.sync.TodoTagForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 interface LocalTagDataSource {
     suspend fun insertTag(tag: TodoTag): Long

--- a/core/database/src/main/java/com/tgyuu/database/source/tag/LocalTagDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/tag/LocalTagDataSourceImpl.kt
@@ -1,11 +1,12 @@
 package com.tgyuu.database.source.tag
 
+import com.tgyuu.common.now
 import com.tgyuu.database.dao.TodoTagsDao
 import com.tgyuu.database.model.TodoTagEntity
 import com.tgyuu.database.model.toEntity
 import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.domain.model.sync.TodoTagForSync
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 
 class LocalTagDataSourceImpl @Inject constructor(

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
@@ -6,8 +6,8 @@ import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 interface LocalTodoDataSource {
     suspend fun getTodoSchedule(id: Int): TodoSchedule?

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
@@ -9,8 +9,8 @@ import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 
 class LocalTodoDataSourceImpl @Inject constructor(

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -16,5 +16,5 @@ dependencies {
     implementation(projects.core.common)
 
     implementation(libs.androidx.datastore)
-    testImplementation(libs.androidx.datastore.core)
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSource.kt
@@ -1,18 +1,18 @@
 package com.tgyuu.datastore.datasource.sync
 
 import kotlinx.coroutines.flow.Flow
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 
 interface LocalSyncDataSource {
     val uuid: Flow<String>
     val connectedUuid: Flow<String?>
     val connectCode: Flow<String?>
-    val lastSyncTime: Flow<ZonedDateTime?>
-    val connectCodeExpirationTime: Flow<ZonedDateTime?>
+    val lastSyncTime: Flow<LocalDateTime?>
+    val connectCodeExpirationTime: Flow<LocalDateTime?>
     suspend fun ensureUUIDExists()
     suspend fun setUuid(uuid: String)
     suspend fun setConnectedUuid(uuid: String?)
     suspend fun setConnectCode(linkCode: String?)
-    suspend fun setLastSyncTime(time: ZonedDateTime?)
-    suspend fun setConnectCodeExpirationTime(time: ZonedDateTime?)
+    suspend fun setLastSyncTime(time: LocalDateTime?)
+    suspend fun setConnectCodeExpirationTime(time: LocalDateTime?)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSourceImpl.kt
@@ -6,7 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -25,13 +25,13 @@ class LocalSyncDataSourceImpl @Inject constructor(
         get() = dataStore.data
             .map { prefs -> prefs[CONNECT_CODE] }
 
-    override val lastSyncTime: Flow<ZonedDateTime?>
+    override val lastSyncTime: Flow<LocalDateTime?>
         get() = dataStore.data
-            .map { prefs -> prefs[LAST_SYNC_TIME]?.let { ZonedDateTime.parse(it) } }
+            .map { prefs -> prefs[LAST_SYNC_TIME]?.let { LocalDateTime.parse(it) } }
 
-    override val connectCodeExpirationTime: Flow<ZonedDateTime?>
+    override val connectCodeExpirationTime: Flow<LocalDateTime?>
         get() = dataStore.data
-            .map { prefs -> prefs[CONNECT_CODE_EXPIRATION_TIME]?.let { ZonedDateTime.parse(it) } }
+            .map { prefs -> prefs[CONNECT_CODE_EXPIRATION_TIME]?.let { LocalDateTime.parse(it) } }
 
     override suspend fun ensureUUIDExists() {
         dataStore.edit { prefs ->
@@ -45,6 +45,7 @@ class LocalSyncDataSourceImpl @Inject constructor(
     override suspend fun setUuid(uuid: String) {
         dataStore.edit { prefs -> prefs[UUID] = uuid }
     }
+
     override suspend fun setConnectedUuid(uuid: String?) {
         dataStore.edit { prefs ->
             if (uuid == null) {
@@ -66,7 +67,7 @@ class LocalSyncDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun setLastSyncTime(time: ZonedDateTime?) {
+    override suspend fun setLastSyncTime(time: LocalDateTime?) {
         dataStore.edit { prefs ->
             if (time == null) {
                 prefs.remove(LAST_SYNC_TIME)
@@ -76,7 +77,7 @@ class LocalSyncDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun setConnectCodeExpirationTime(time: ZonedDateTime?) {
+    override suspend fun setConnectCodeExpirationTime(time: LocalDateTime?) {
         dataStore.edit { prefs ->
             if (time == null) {
                 prefs.remove(CONNECT_CODE_EXPIRATION_TIME)

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -10,6 +10,8 @@ android {
 dependencies {
     implementation(projects.core.commonUi)
     implementation(projects.core.domain)
+    implementation(projects.core.common)
 
+    implementation(libs.kotlinx.datetime)
     implementation(libs.androidx.metrics.performance)
 }

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
@@ -11,9 +11,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.tgyuu.common.now
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
 
 @Composable
 fun EbbingCalendar(
@@ -31,7 +34,10 @@ fun EbbingCalendar(
     val currentOffset = pagerState.currentPage - initialPage
 
     LaunchedEffect(pagerState.currentPage) {
-        val newDate = calendarState.originSelectedDate.plusMonths(currentOffset.toLong())
+        val newDate = calendarState.originSelectedDate.plus(
+            value = currentOffset.toLong(),
+            unit = DateTimeUnit.MONTH,
+        )
         calendarState.currentDisplayDate = newDate
     }
 

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarBody.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarBody.kt
@@ -34,10 +34,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.tgyuu.common.now
 import com.tgyuu.common.util.ebbingAnimateColorAsState
 import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun CalendarBody(

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarController.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarController.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.tgyuu.common.now
 import com.tgyuu.common.util.clickable
 import com.tgyuu.designsystem.R
 import com.tgyuu.designsystem.foundation.EbbingTheme
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 @Composable
 internal fun CalendarController(
@@ -53,7 +55,7 @@ internal fun CalendarController(
         }
 
         Text(
-            text = "${currentDate.year}년 ${currentDate.monthValue}월",
+            text = "${currentDate.year}년 ${currentDate.month.number}월",
             textAlign = TextAlign.Center,
             style = EbbingTheme.typography.headingSSB,
             color = EbbingTheme.colors.black,

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarDate.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarDate.kt
@@ -1,14 +1,19 @@
 package com.tgyuu.designsystem.component.calendar
 
-import java.time.DayOfWeek
-import java.time.DayOfWeek.FRIDAY
-import java.time.DayOfWeek.MONDAY
-import java.time.DayOfWeek.SATURDAY
-import java.time.DayOfWeek.SUNDAY
-import java.time.DayOfWeek.THURSDAY
-import java.time.DayOfWeek.TUESDAY
-import java.time.DayOfWeek.WEDNESDAY
-import java.time.LocalDate
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.DayOfWeek.FRIDAY
+import kotlinx.datetime.DayOfWeek.MONDAY
+import kotlinx.datetime.DayOfWeek.SATURDAY
+import kotlinx.datetime.DayOfWeek.SUNDAY
+import kotlinx.datetime.DayOfWeek.THURSDAY
+import kotlinx.datetime.DayOfWeek.TUESDAY
+import kotlinx.datetime.DayOfWeek.WEDNESDAY
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
 
 val EbbingDayOfWeek = listOf(
     SUNDAY,
@@ -36,22 +41,29 @@ fun getCalendarDates(date: LocalDate): List<CalendarDate> {
 }
 
 private fun getPreviousMonthDatesToShow(date: LocalDate): List<CalendarDate> {
-    val firstDayOfMonth = date.withDayOfMonth(1)
-    val previousMonth = firstDayOfMonth.minusMonths(1)
-    val lastDayOfPreviousMonth = previousMonth.lengthOfMonth()
-
+    val firstDayOfMonth = LocalDate(date.year, date.month.number, 1)
+    val previousMonth = LocalDate(firstDayOfMonth.year, firstDayOfMonth.month.number, 1)
+        .minus(1, DateTimeUnit.MONTH)
+    val lastDayOfPreviousMonth = previousMonth.totalDaysInMonth()
     val count = getPreviousMonthDayOfWeeksToShow(date).size
 
     return ((lastDayOfPreviousMonth - count + 1)..lastDayOfPreviousMonth).map {
-        CalendarDate(previousMonth.withDayOfMonth(it), isCurrentMonth = false)
+        CalendarDate(
+            LocalDate(previousMonth.year, previousMonth.month.number, it),
+            isCurrentMonth = false
+        )
     }
 }
 
 private fun getCurrentMonthDatesToShow(date: LocalDate): List<CalendarDate> {
-    val yearMonth = date.withDayOfMonth(1)
-    val lastDay = yearMonth.lengthOfMonth()
+    val firstDayOfMonth = LocalDate(date.year, date.month.number, 1)
+    val lastDay = firstDayOfMonth.totalDaysInMonth()
+
     return (1..lastDay).map { day ->
-        CalendarDate(yearMonth.withDayOfMonth(day), isCurrentMonth = true)
+        CalendarDate(
+            date = LocalDate(date.year, date.month.number, day),
+            isCurrentMonth = true,
+        )
     }
 }
 
@@ -60,9 +72,13 @@ private fun getNextMonthDatesToShow(date: LocalDate): List<CalendarDate> {
         getPreviousMonthDatesToShow(date).size + getCurrentMonthDatesToShow(date).size
     val remainCount = 42 - totalDayCountUntilNextMonth
 
-    val nextMonth = date.withDayOfMonth(1).plusMonths(1)
+    val nextMonth = LocalDate(date.year, date.month.number, 1).plus(1, DateTimeUnit.MONTH)
+
     return (1..remainCount).map {
-        CalendarDate(nextMonth.withDayOfMonth(it), isCurrentMonth = false)
+        CalendarDate(
+            date = LocalDate(nextMonth.year, nextMonth.month.number, it),
+            isCurrentMonth = false
+        )
     }
 }
 
@@ -73,16 +89,24 @@ private fun getNextMonthDatesToShow(date: LocalDate): List<CalendarDate> {
  */
 private fun getPreviousMonthDayOfWeeksToShow(date: LocalDate): List<DayOfWeek> {
     val firstDayOfWeek = getFirstDayOfWeek(date)
-    val count = (firstDayOfWeek.value % 7) // SUNDAY(7) % 7 = 0 → 일요일 기준
+    val count = firstDayOfWeek.isoDayNumber % 7 // 일요일 기준 0~6
 
-    return (0 until count).map {
-        DayOfWeek.of((it + 1))
-    }
+    val allDays = DayOfWeek.entries // SUNDAY ~ SATURDAY 순서
+    return (0 until count).map { allDays[it] }
 }
 
 /**
  * 해당 날짜의 달에 1일의 요일을 구합니다.
  */
 private fun getFirstDayOfWeek(date: LocalDate): DayOfWeek {
-    return date.withDayOfMonth(1).dayOfWeek
+    return LocalDate(date.year, date.month.number, 1).dayOfWeek
+}
+
+
+fun LocalDate.totalDaysInMonth(): Int {
+    // 다음 달 1일
+    val nextMonth = this.plus(1, DateTimeUnit.MONTH).run { LocalDate(year, monthNumber, 1) }
+    // 다음 달 1일에서 하루 빼기 = 이번 달 마지막 날
+    val lastDayOfMonth = nextMonth.minus(1, DateTimeUnit.DAY)
+    return lastDayOfMonth.day
 }

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarState.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarState.kt
@@ -5,7 +5,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.setValue
-import java.time.LocalDate
+import com.tgyuu.common.now
+import kotlinx.datetime.LocalDate
 
 class CalendarState(val originSelectedDate: LocalDate = LocalDate.now()) {
     var currentDisplayDate by mutableStateOf(originSelectedDate)

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarUtil.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarUtil.kt
@@ -1,7 +1,8 @@
 package com.tgyuu.designsystem.component.calendar
 
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 fun DayOfWeek.toKorean(): String = when (this) {
     DayOfWeek.SUNDAY -> "일"
@@ -14,7 +15,7 @@ fun DayOfWeek.toKorean(): String = when (this) {
 }
 
 fun yearMonthDiff(from: LocalDate, to: LocalDate): Int {
-    return (to.year - from.year) * 12 + (to.monthValue - from.monthValue)
+    return (to.year - from.year) * 12 + (to.month.number - from.month.number)
 }
 
 internal const val COLOR_ANIM_THRESHOLD = 5L * 1024 * 1024

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/model/TodoScheduleUiModel.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/model/TodoScheduleUiModel.kt
@@ -1,6 +1,6 @@
 package com.tgyuu.designsystem.model
 
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 data class TodoScheduleUiModel(
     val id: Int,

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.coroutines.core)
     implementation(projects.core.common)
+
+    implementation(libs.coroutines.core)
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/domain/src/main/java/com/tgyuu/domain/model/TodoSchedule.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/TodoSchedule.kt
@@ -1,6 +1,6 @@
 package com.tgyuu.domain.model
 
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 data class TodoSchedule(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/model/TodoTag.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/TodoTag.kt
@@ -1,6 +1,7 @@
 package com.tgyuu.domain.model
 
-import java.time.LocalDate
+import com.tgyuu.common.now
+import kotlinx.datetime.LocalDate
 
 data class TodoTag(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/ConnectInfo.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/ConnectInfo.kt
@@ -1,6 +1,7 @@
 package com.tgyuu.domain.model.sync
 
-import java.time.LocalDateTime
+import com.tgyuu.common.now
+import kotlinx.datetime.LocalDateTime
 
 data class ConnectInfo(
     val uuid: String,
@@ -9,6 +10,6 @@ data class ConnectInfo(
 ) {
     fun isValid(): Boolean {
         val now = LocalDateTime.now()
-        return connectCodeExpirationTime.isAfter(now)
+        return connectCodeExpirationTime > now
     }
 }

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/RepeatCycleForSync.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/RepeatCycleForSync.kt
@@ -1,6 +1,6 @@
 package com.tgyuu.domain.model.sync
 
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 
 data class RepeatCycleForSync(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoInfoForSync.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoInfoForSync.kt
@@ -1,7 +1,7 @@
 package com.tgyuu.domain.model.sync
 
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 data class TodoInfoForSync(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoScheduleForSync.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoScheduleForSync.kt
@@ -1,7 +1,7 @@
 package com.tgyuu.domain.model.sync
 
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 data class TodoScheduleForSync(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoTagForSync.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoTagForSync.kt
@@ -1,7 +1,7 @@
 package com.tgyuu.domain.model.sync
 
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 
 data class TodoTagForSync(
     val id: Int,

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
@@ -1,18 +1,18 @@
 package com.tgyuu.domain.repository
 
 import com.tgyuu.domain.model.sync.ConnectInfo
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 
 interface SyncRepository {
     suspend fun ensureUUIDExists()
     suspend fun getUuid(): String
     suspend fun getConnectedUuid(): String?
-    suspend fun getServerLastUpdatedAt(): ZonedDateTime?
-    suspend fun getLocalSyncedAt(): ZonedDateTime?
-    suspend fun syncUpData(): ZonedDateTime
-    suspend fun generateConnectCode(connectCode: String): ZonedDateTime
+    suspend fun getServerLastUpdatedAt(): LocalDateTime?
+    suspend fun getLocalSyncedAt(): LocalDateTime?
+    suspend fun syncUpData(): LocalDateTime
+    suspend fun generateConnectCode(connectCode: String): LocalDateTime
     suspend fun getMyConnectCode(): String?
-    suspend fun getConnectCodeExpiration(): ZonedDateTime?
+    suspend fun getConnectCodeExpiration(): LocalDateTime?
     suspend fun connectAnother(connectCode: String): ConnectInfo?
     suspend fun disconnectAnother()
 }

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
@@ -5,7 +5,7 @@ import com.tgyuu.domain.model.TodoInfo
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.TodoTag
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 interface TodoRepository {
     val recentAddedTagId: Long?

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(projects.core.common)
 
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.firebase.config)
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.storage)

--- a/core/network/src/main/java/com/tgyuu/network/FireStoreUtil.kt
+++ b/core/network/src/main/java/com/tgyuu/network/FireStoreUtil.kt
@@ -4,33 +4,61 @@ import com.google.android.gms.tasks.Task
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentSnapshot
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.time.LocalDate
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.util.Date
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.time.ExperimentalTime
 
-val defaultDate = LocalDateTime.of(1970, 1, 1, 0, 0).toDate()
+val defaultDate = LocalDateTime(1970, 1, 1, 0, 0).toDate()
 
 // FireStore timeStamp? -> ZonedDateTime? 로 변환해주는 확장함수
-fun Timestamp?.toZonedDateTimeOrNull(): ZonedDateTime? {
-    return this?.toDate()
-        ?.toInstant()
-        ?.atZone(ZoneId.systemDefault())
+fun Timestamp?.toLocalDateTimeOrNull(): LocalDateTime? {
+    return this?.toDate()?.toLocalDateTime()
 }
 
-fun LocalDate.toDate(): Date = Date.from(this.atStartOfDay(ZoneId.systemDefault()).toInstant())
-fun LocalDateTime.toDate(): Date = Date.from(this.atZone(ZoneId.systemDefault()).toInstant())
+fun LocalDate.toDate(): Date = LocalDateTime(
+    year = this.year,
+    month = this.month.number,
+    day = this.day,
+    hour = 0,
+    minute = 0,
+).toDate()
 
-fun Date.toLocalDate(): LocalDate = this.toInstant()
-    .atZone(ZoneId.systemDefault())
-    .toLocalDate()
+@OptIn(ExperimentalTime::class)
+fun LocalDateTime.toDate(): Date {
+    val instant = this.toInstant(TimeZone.currentSystemDefault())
+    return Date(instant.toEpochMilliseconds())
+}
 
-fun Date.toLocalDateTime(): LocalDateTime = this.toInstant()
-    .atZone(ZoneId.systemDefault())
-    .toLocalDateTime()
+fun Date.toLocalDate(): LocalDate {
+    val instant = this.toInstant()
+    val zdt = instant.atZone(java.time.ZoneId.systemDefault())
+    return LocalDate(
+        year = zdt.year,
+        month = zdt.monthValue,
+        day = zdt.dayOfMonth
+    )
+}
+
+fun Date.toLocalDateTime(): LocalDateTime {
+    val instant = this.toInstant()
+    val ldt = instant.atZone(ZoneId.systemDefault()).toLocalDateTime()
+    return LocalDateTime(
+        year = ldt.year,
+        month = ldt.monthValue,
+        day = ldt.dayOfMonth,
+        hour = ldt.hour,
+        minute = ldt.minute,
+        second = ldt.second,
+        nanosecond = ldt.nano
+    )
+}
 
 // FireStore CallBack을 SuspendCancellableCoroutine으로 감싼 뒤 T를 반환
 suspend inline fun <reified T> Task<DocumentSnapshot>.toResponse(): T =

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/ConnectDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/ConnectDto.kt
@@ -1,9 +1,10 @@
 package com.tgyuu.network.model.sync
 
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.sync.ConnectInfo
 import com.tgyuu.network.toDate
 import com.tgyuu.network.toLocalDateTime
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 import java.util.Date
 
 data class ConnectDto(

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/SyncInfoDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/SyncInfoDto.kt
@@ -1,9 +1,9 @@
 package com.tgyuu.network.model.sync
 
 import com.google.firebase.Timestamp
-import com.tgyuu.network.toZonedDateTimeOrNull
-import java.time.ZonedDateTime
+import com.tgyuu.network.toLocalDateTimeOrNull
+import kotlinx.datetime.LocalDateTime
 
 data class SyncInfoDto(val lastUpdatedAt: Timestamp? = null) {
-    fun toDomain(): ZonedDateTime? = lastUpdatedAt?.toZonedDateTimeOrNull()
+    fun toDomain(): LocalDateTime? = lastUpdatedAt?.toLocalDateTimeOrNull()
 }

--- a/core/network/src/main/java/com/tgyuu/network/source/SyncDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SyncDataSource.kt
@@ -3,6 +3,8 @@ package com.tgyuu.network.source
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue.serverTimestamp
 import com.google.firebase.firestore.FirebaseFirestore
+import com.tgyuu.common.copy
+import com.tgyuu.common.now
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
 import com.tgyuu.domain.model.sync.TodoInfoForSync
@@ -17,15 +19,15 @@ import com.tgyuu.network.model.sync.TodoScheduleDto
 import com.tgyuu.network.model.sync.TodoTagDto
 import com.tgyuu.network.model.sync.toDto
 import com.tgyuu.network.toDate
+import com.tgyuu.network.toLocalDateTime
+import com.tgyuu.network.toLocalDateTimeOrNull
 import com.tgyuu.network.toResponse
-import com.tgyuu.network.toZonedDateTimeOrNull
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import java.time.LocalDateTime
+import kotlinx.datetime.LocalDateTime
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.util.Date
 import javax.inject.Inject
 
@@ -47,7 +49,7 @@ class SyncDataSource @Inject constructor(
         infos: List<TodoInfoForSync>,
         repeatCycles: List<RepeatCycleForSync>,
         tags: List<TodoTagForSync>,
-    ): ZonedDateTime = coroutineScope {
+    ): LocalDateTime = coroutineScope {
         val userDoc = firestore.collection(COLLECTION_USERS).document(uuid)
 
         val schedulesJob = launch {
@@ -97,7 +99,7 @@ class SyncDataSource @Inject constructor(
         val updatedSnapshot = infoDocRef.get().await()
         updatedSnapshot
             .getTimestamp(FIELD_LAST_UPDATED_AT)
-            .toZonedDateTimeOrNull()
+            .toLocalDateTimeOrNull()
             ?: throw IllegalStateException("lastUpdatedAt 가 비었습니다.")
     }
 
@@ -162,14 +164,12 @@ class SyncDataSource @Inject constructor(
         }
     }
 
-    suspend fun generateConnectCode(uuid: String, connectCode: String): ZonedDateTime {
+    suspend fun generateConnectCode(uuid: String, connectCode: String): LocalDateTime {
         val connectCodeDoc = firestore.collection(COLLECTION_CONNECT_CODES)
             .document(connectCode)
 
-        val connectCodeExpirationTime = LocalDateTime.now()
-            .plusMinutes(10L)
-            .toDate()
-
+        val now = LocalDateTime.now()
+        val connectCodeExpirationTime = now.copy(minute = now.minute + 10).toDate()
         val connectDto = ConnectDto(
             uuid = uuid,
             connectCode = connectCode,
@@ -179,8 +179,7 @@ class SyncDataSource @Inject constructor(
         connectCodeDoc.set(connectDto)
             .await()
 
-        return connectCodeExpirationTime.toInstant()
-            .atZone(ZoneId.systemDefault())
+        return connectCodeExpirationTime.toLocalDateTime()
     }
 
     suspend fun connectAnother(connectCode: String): Result<ConnectDto?> = suspendRunCatching {

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -20,4 +20,6 @@ android {
 dependencies {
     implementation(projects.core.common)
     implementation(projects.core.alarm)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.tgyuu.common.now
 import com.tgyuu.common.util.throttledClickable
 import com.tgyuu.designsystem.BasePreview
 import com.tgyuu.designsystem.EbbingPreview
@@ -49,8 +50,9 @@ import com.tgyuu.home.graph.ui.RestDayContent
 import com.tgyuu.home.graph.ui.ScheduleContent
 import com.tgyuu.home.graph.ui.TagContent
 import com.tgyuu.home.graph.ui.TitleContent
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 @Composable
 internal fun AddTodoRoute(
@@ -339,7 +341,7 @@ private fun TodoMainFormContent(
     Text(
         text = buildAnnotatedString {
             withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-                append("${state.selectedDate.monthValue}월 ${state.selectedDate.dayOfMonth}일")
+                append("${state.selectedDate.month.number}월 ${state.selectedDate.day}일")
             }
             append(" 부터\n시작하는 일정을 만들어요")
         },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -25,11 +25,14 @@ import com.tgyuu.navigation.RepeatCycleGraph
 import com.tgyuu.navigation.TagGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneId
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class AddTodoViewModel @Inject constructor(
@@ -166,6 +169,7 @@ class AddTodoViewModel @Inject constructor(
         navigationBus.navigate(NavigationEvent.To(RepeatCycleGraph.AddRepeatCycleRoute))
     }
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun onSaveClick() {
         if (!currentState.isSaveEnabled) {
             eventBus.sendEvent(EbbingEvent.ShowSnackBar("필수 항목을 작성해주세요"))
@@ -182,11 +186,18 @@ class AddTodoViewModel @Inject constructor(
         val (hour, minute) = configRepository.getAlarmTime()
         currentState.schedules.forEach { schedule ->
             try {
-                val triggerAtMillis = schedule
-                    .atTime(LocalTime.of(hour, minute))
-                    .atZone(ZoneId.systemDefault())
-                    .toInstant()
-                    .toEpochMilli()
+                val triggerAtMillis = schedule.run {
+                    val dateTime = LocalDateTime(
+                        year = this.year,
+                        month = this.month.number,
+                        day = this.day,
+                        hour = hour,
+                        minute = minute,
+                        second = 0,
+                        nanosecond = 0
+                    )
+                    dateTime.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+                }
 
                 if (triggerAtMillis <= System.currentTimeMillis()) return@forEach
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoIntent.kt
@@ -4,8 +4,8 @@ import com.tgyuu.common.base.UiIntent
 import com.tgyuu.common.event.BottomSheetContent
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.TodoTag
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 
 sealed class AddTodoIntent : UiIntent {
     data object OnBackClick : AddTodoIntent()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
@@ -2,12 +2,13 @@ package com.tgyuu.home.graph.addtodo.contract
 
 import com.tgyuu.common.base.UiState
 import com.tgyuu.common.generateValidSchedules
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.DefaultRepeatCycles
 import com.tgyuu.domain.model.DefaultTodoTag
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.TodoTag
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 
 data class AddTodoState(
     val selectedDate: LocalDate = LocalDate.now(),

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/ui/bottomsheet/SelectedDateBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/ui/bottomsheet/SelectedDateBottomSheet.kt
@@ -14,7 +14,7 @@ import com.tgyuu.designsystem.component.EbbingSolidButton
 import com.tgyuu.designsystem.component.calendar.EbbingCalendar
 import com.tgyuu.designsystem.component.calendar.rememberCalendarState
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun SelectedDateBottomSheet(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.tgyuu.common.now
 import com.tgyuu.common.util.throttledClickable
 import com.tgyuu.designsystem.BasePreview
 import com.tgyuu.designsystem.EbbingPreview
@@ -43,8 +44,9 @@ import com.tgyuu.home.graph.editdate.contract.EditDateState
 import com.tgyuu.home.graph.ui.RepeatCycleContent
 import com.tgyuu.home.graph.ui.RestDayContent
 import com.tgyuu.home.graph.ui.ScheduleCheckContent
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 @Composable
 internal fun EditDateRoute(
@@ -297,7 +299,7 @@ private fun EditDateMainFormContent(
     Text(
         text = buildAnnotatedString {
             withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-                append("${state.selectedDate.monthValue}월 ${state.selectedDate.dayOfMonth}일")
+                append("${state.selectedDate.month.number}월 ${state.selectedDate.day}일")
             }
             append(" 부터\n시작하는 일정으로 바꿔요")
         },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
@@ -22,11 +22,14 @@ import com.tgyuu.navigation.NavigationEvent
 import com.tgyuu.navigation.RepeatCycleGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneId
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class EditDateViewModel @Inject constructor(
@@ -131,6 +134,7 @@ class EditDateViewModel @Inject constructor(
         navigationBus.navigate(NavigationEvent.To(RepeatCycleGraph.AddRepeatCycleRoute))
     }
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun onSaveClick(isDoneSchedules: List<Boolean>) {
         if (currentState.schedules.isEmpty()) {
             eventBus.sendEvent(EbbingEvent.ShowSnackBar("저장할 일정이 없습니다"))
@@ -154,11 +158,18 @@ class EditDateViewModel @Inject constructor(
         val (hour, minute) = configRepository.getAlarmTime()
         currentState.schedules.forEach { schedule ->
             try {
-                val triggerAtMillis = schedule
-                    .atTime(LocalTime.of(hour, minute))
-                    .atZone(ZoneId.systemDefault())
-                    .toInstant()
-                    .toEpochMilli()
+                val triggerAtMillis = schedule.run {
+                    val dateTime = LocalDateTime(
+                        year = this.year,
+                        month = this.month.number,
+                        day = this.day,
+                        hour = hour,
+                        minute = minute,
+                        second = 0,
+                        nanosecond = 0
+                    )
+                    dateTime.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+                }
 
                 if (triggerAtMillis <= System.currentTimeMillis()) return@forEach
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateIntent.kt
@@ -3,8 +3,8 @@ package com.tgyuu.home.graph.editdate.contract
 import com.tgyuu.common.base.UiIntent
 import com.tgyuu.common.event.BottomSheetContent
 import com.tgyuu.domain.model.RepeatCycle
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 
 sealed class EditDateIntent : UiIntent {
     data object OnBackClick : EditDateIntent()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
@@ -2,10 +2,11 @@ package com.tgyuu.home.graph.editdate.contract
 
 import com.tgyuu.common.base.UiState
 import com.tgyuu.common.generateValidSchedules
+import com.tgyuu.common.now
 import com.tgyuu.domain.model.DefaultRepeatCycles
 import com.tgyuu.domain.model.RepeatCycle
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 
 data class EditDateState(
     val title: String = "",

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/ui/bottomsheet/SelectedDateBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/ui/bottomsheet/SelectedDateBottomSheet.kt
@@ -14,7 +14,7 @@ import com.tgyuu.designsystem.component.EbbingSolidButton
 import com.tgyuu.designsystem.component.calendar.EbbingCalendar
 import com.tgyuu.designsystem.component.calendar.rememberCalendarState
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun SelectedDateBottomSheet(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.tgyuu.common.now
 import com.tgyuu.common.util.throttledClickable
 import com.tgyuu.designsystem.BasePreview
 import com.tgyuu.designsystem.EbbingPreview
@@ -40,7 +41,8 @@ import com.tgyuu.home.graph.edittodo.contract.EditTodoState
 import com.tgyuu.home.graph.ui.PriorityContent
 import com.tgyuu.home.graph.ui.TagContent
 import com.tgyuu.home.graph.ui.TitleContent
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 @Composable
 internal fun EditTodoRoute(
@@ -140,7 +142,7 @@ private fun EditTodoScreen(
             Text(
                 text = buildAnnotatedString {
                     withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
-                        append("${state.selectedDate.monthValue}월 ${state.selectedDate.dayOfMonth}일")
+                        append("${state.selectedDate.month.number}월 ${state.selectedDate.day}일")
                     }
                     append(" 에\n진행하는 걸로 바꿀래요")
                 },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
@@ -8,6 +8,7 @@ import com.tgyuu.common.base.BaseViewModel
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EbbingEvent.ShowBottomSheet
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.toFormattedString
 import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.domain.repository.ConfigRepository
@@ -22,11 +23,13 @@ import com.tgyuu.navigation.TagGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneId
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class EditTodoViewModel @Inject constructor(
@@ -147,6 +150,7 @@ class EditTodoViewModel @Inject constructor(
         navigationBus.navigate(NavigationEvent.To(TagGraph.AddTagRoute))
     }
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun onSaveClick() {
         if (!currentState.isSaveEnabled) {
             eventBus.sendEvent(EbbingEvent.ShowSnackBar("필수 항목을 작성해주세요"))
@@ -169,12 +173,19 @@ class EditTodoViewModel @Inject constructor(
         currentState.originSchedule?.date?.let { originDate ->
             if (newSchedule.date != originDate) {
                 // 새 날짜가 오늘 이후면 알람 재등록
-                if (newSchedule.date.isAfter(LocalDate.now())) {
-                    val triggerAtMillis = newSchedule.date
-                        .atTime(LocalTime.of(hour, minute))
-                        .atZone(ZoneId.systemDefault())
-                        .toInstant()
-                        .toEpochMilli()
+                if (newSchedule.date > LocalDate.now()) {
+                    val triggerAtMillis = newSchedule.date.run {
+                        val dateTime = LocalDateTime(
+                            year = this.year,
+                            month = this.month.number,
+                            day = this.day,
+                            hour = hour,
+                            minute = minute,
+                            second = 0,
+                            nanosecond = 0
+                        )
+                        dateTime.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+                    }
 
                     alarmScheduler.scheduleDailyExact(
                         date = newSchedule.date,

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoIntent.kt
@@ -3,7 +3,7 @@ package com.tgyuu.home.graph.edittodo.contract
 import com.tgyuu.common.base.UiIntent
 import com.tgyuu.common.event.BottomSheetContent
 import com.tgyuu.domain.model.TodoTag
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 sealed class EditTodoIntent : UiIntent {
     data object OnBackClick : EditTodoIntent()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoState.kt
@@ -2,14 +2,15 @@ package com.tgyuu.home.graph.edittodo.contract
 
 import com.tgyuu.common.base.UiState
 import com.tgyuu.common.generateValidSchedules
+import com.tgyuu.common.now
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.DefaultRepeatCycles
 import com.tgyuu.domain.model.DefaultTodoTag
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.model.TodoTag
-import java.time.DayOfWeek
-import java.time.LocalDate
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 
 data class EditTodoState(
     val schedulesByDateMap: Map<LocalDate, List<TodoScheduleUiModel>> = emptyMap(),

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.tgyuu.common.event.EbbingEvent
+import com.tgyuu.common.now
 import com.tgyuu.common.util.throttledClickable
 import com.tgyuu.designsystem.BasePreview
 import com.tgyuu.designsystem.EbbingPreview
@@ -63,7 +64,7 @@ import com.tgyuu.home.graph.main.ui.dialog.DialogType.ConfirmDeleteRemaining
 import com.tgyuu.home.graph.main.ui.dialog.DialogType.ConfirmDeleteSingle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun HomeRoute(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -3,10 +3,13 @@ package com.tgyuu.home.graph.main
 import androidx.lifecycle.viewModelScope
 import com.tgyuu.alarm.AlarmScheduler
 import com.tgyuu.common.base.BaseViewModel
+import com.tgyuu.common.copy
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EbbingEvent.ShowBottomSheet
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.toFormattedString
+import com.tgyuu.designsystem.component.calendar.totalDaysInMonth
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.SortType
 import com.tgyuu.domain.model.TodoSchedule
@@ -24,10 +27,16 @@ import com.tgyuu.navigation.NavigationEvent.To
 import com.tgyuu.navigation.SyncGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZoneId
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -49,8 +58,8 @@ class HomeViewModel @Inject constructor(
 
     suspend fun initCurrentMonthSchedules() {
         val today = LocalDate.now()
-        val start = today.withDayOfMonth(1)
-        val end = today.withDayOfMonth(today.lengthOfMonth())
+        val start = today.copy(day = 1)
+        val end = today.copy(today.totalDaysInMonth())
 
         currentMonthSchedules = todoRepository.loadTodoSchedulesByDateRange(start, end)
     }
@@ -83,8 +92,10 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun loadSchedules(currentDate: LocalDate) = viewModelScope.launch {
-        val start = currentDate.withDayOfMonth(1).minusMonths(1)
-        val end = currentDate.withDayOfMonth(1).plusMonths(2).minusDays(1)
+        val start = currentDate.minus(1, DateTimeUnit.MONTH)
+            .run { LocalDate(year, month, 1) }
+        val end = currentDate.plus(1, DateTimeUnit.MONTH)
+            .run { LocalDate(year, month, totalDaysInMonth()) }
 
         val rangeSchedules = todoRepository.loadTodoSchedulesByDateRange(start, end)
         cachedSchedules = (currentMonthSchedules + rangeSchedules).distinctBy { it.id }
@@ -177,8 +188,9 @@ class HomeViewModel @Inject constructor(
         eventBus.sendEvent(EbbingEvent.ShowSnackBar("해당 일정 이후 연계된 일정들을 모두 지웠습니다."))
     }
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun onDelaySchedule(schedule: TodoSchedule) {
-        val nextDate = schedule.date.plusDays(1)
+        val nextDate = schedule.date.plus(1, DateTimeUnit.DAY)
         val alreadyExistsOnNext = currentState
             .schedulesByDateMap[nextDate]
             ?.any { it.infoId == schedule.infoId } == true
@@ -193,12 +205,19 @@ class HomeViewModel @Inject constructor(
         todoRepository.updateTodo(delayed)
         val (hour, minute) = configRepository.getAlarmTime()
 
-        if (nextDate.isAfter(LocalDate.now())) {
-            val triggerAtMillis = nextDate
-                .atTime(LocalTime.of(hour, minute))
-                .atZone(ZoneId.systemDefault())
-                .toInstant()
-                .toEpochMilli()
+        if (nextDate > LocalDate.now()) {
+            val triggerAtMillis = nextDate.run {
+                val dateTime = LocalDateTime(
+                    year = this.year,
+                    month = this.month.number,
+                    day = this.day,
+                    hour = hour,
+                    minute = minute,
+                    second = 0,
+                    nanosecond = 0
+                )
+                dateTime.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+            }
 
             alarmScheduler.scheduleDailyExact(
                 date = nextDate,

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
@@ -4,7 +4,7 @@ import com.tgyuu.common.base.UiIntent
 import com.tgyuu.common.event.BottomSheetContent
 import com.tgyuu.domain.model.SortType
 import com.tgyuu.domain.model.TodoSchedule
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 sealed interface HomeIntent : UiIntent {
     data class OnCurrentDateChanged(val currentDate: LocalDate) : HomeIntent

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeState.kt
@@ -3,7 +3,7 @@ package com.tgyuu.home.graph.main.contract
 import com.tgyuu.common.base.UiState
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.SortType
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 data class HomeState(
     val isLoading: Boolean = true,

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
@@ -33,12 +33,16 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.tgyuu.common.now
 import com.tgyuu.common.util.clickable
 import com.tgyuu.designsystem.component.TodoListCard
 import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.SortType
-import java.time.LocalDate
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
 
 @Composable
 internal fun EbbingTodoList(
@@ -64,7 +68,7 @@ internal fun EbbingTodoList(
         val newPage = pagerState.currentPage
         val delta = newPage - prevPage
         if (delta != 0) {
-            onSelectDate(selectedDate.plusDays(delta.toLong()))
+            onSelectDate(selectedDate.plus(delta.toLong(), DateTimeUnit.DAY))
             prevPage = newPage
         }
     }
@@ -108,7 +112,7 @@ private fun TodoHeader(
             .padding(horizontal = 20.dp, vertical = 8.dp)
     ) {
         val dateText = if (displayDate == LocalDate.now()) "오늘"
-        else "${displayDate.monthValue}월 ${displayDate.dayOfMonth}일"
+        else "${displayDate.month.number}월 ${displayDate.day}일"
         Text(
             text = "$dateText  할 일 $count",
             style = EbbingTheme.typography.bodyMSB,
@@ -181,7 +185,7 @@ private fun TodoPage(
         }
     } else {
         Text(
-            text = "${date.monthValue}월 ${date.dayOfMonth}일 스케줄이 없어요.\n" +
+            text = "${date.month.number}월 ${date.day}일 스케줄이 없어요.\n" +
                     "우측 상단 + 버튼을 눌러 새로운 스케줄을 만들어보세요.",
             style = EbbingTheme.typography.bodySM,
             textAlign = TextAlign.Center,

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteRemainingDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteRemainingDialog.kt
@@ -9,6 +9,7 @@ import com.tgyuu.designsystem.component.EbbingDialogBottom
 import com.tgyuu.designsystem.component.EbbingDialogDefaultTop
 import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.domain.model.TodoSchedule
+import kotlinx.datetime.number
 
 @Composable
 internal fun ConfirmDeleteRemainingDialog(
@@ -20,7 +21,7 @@ internal fun ConfirmDeleteRemainingDialog(
         dialogTop = {
             EbbingDialogDefaultTop(
                 title = buildAnnotatedString {
-                    append("${schedule.title} 와 연계된 ${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일 이후 일정을 모두 ")
+                    append("${schedule.title} 와 연계된 ${schedule.date.month.number}월 ${schedule.date.day}일 이후 일정을 모두 ")
                     withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
                         append("삭제")
                     }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/RestDay.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/RestDay.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.tgyuu.designsystem.component.EbbingChip
 import com.tgyuu.designsystem.component.calendar.toKorean
 import com.tgyuu.designsystem.foundation.EbbingTheme
-import java.time.DayOfWeek
+import kotlinx.datetime.DayOfWeek
 
 @Composable
 internal fun RestDayContent(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/Schedule.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/Schedule.kt
@@ -20,7 +20,7 @@ import com.tgyuu.common.util.EbbingVisibleAnimation
 import com.tgyuu.designsystem.component.EbbingCheck
 import com.tgyuu.designsystem.component.calendar.toKorean
 import com.tgyuu.designsystem.foundation.EbbingTheme
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun ScheduleContent(

--- a/feature/home/src/main/java/com/tgyuu/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/navigation/HomeNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
+import com.tgyuu.common.now
 import com.tgyuu.common.toLocalDateOrThrow
 import com.tgyuu.home.graph.addtodo.AddTodoRoute
 import com.tgyuu.home.graph.editdate.EditDateRoute
@@ -12,7 +13,7 @@ import com.tgyuu.navigation.HomeBaseRoute
 import com.tgyuu.navigation.HomeGraph
 import com.tgyuu.navigation.HomeGraph.AddTodoRoute
 import com.tgyuu.navigation.HomeGraph.HomeRoute
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 fun NavGraphBuilder.homeGraph() {
     navigation<HomeBaseRoute>(startDestination = HomeGraph.HomeRoute()) {

--- a/feature/memo/build.gradle.kts
+++ b/feature/memo/build.gradle.kts
@@ -19,4 +19,6 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/schedule/build.gradle.kts
+++ b/feature/schedule/build.gradle.kts
@@ -19,4 +19,6 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -42,4 +42,5 @@ dependencies {
     implementation(projects.core.alarm)
 
     implementation(libs.accompanist.permission)
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
@@ -5,6 +5,7 @@ import com.tgyuu.alarm.AlarmScheduler
 import com.tgyuu.common.base.BaseViewModel
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.ConfigRepository.Companion.DEFAULT_ALARM_MESSAGE
@@ -21,10 +22,12 @@ import com.tgyuu.setting.graph.main.contract.SettingIntent
 import com.tgyuu.setting.graph.main.contract.SettingState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneId
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class SettingViewModel @Inject constructor(
@@ -132,6 +135,7 @@ class SettingViewModel @Inject constructor(
     private suspend fun navigateToWebView(title: String, url: String) =
         navigationBus.navigate(To(SettingGraph.WebViewRoute(title = title, url = url)))
 
+    @OptIn(ExperimentalTime::class)
     private suspend fun updateAlarmTime(hour: String, minute: String) {
         configRepository.updateAlarmTime(hour, minute)
 
@@ -141,10 +145,18 @@ class SettingViewModel @Inject constructor(
         val now = LocalDateTime.now()
 
         upcoming.forEach { sch ->
-            val localDateTime = sch.date.atTime(h, m)
-            if (localDateTime.isBefore(now)) return@forEach
+            val localDateTime = sch.date.run {
+                LocalDateTime(
+                    year = year,
+                    month = month,
+                    day = day,
+                    hour = h,
+                    minute = m,
+                )
+            }
+            if (localDateTime < now) return@forEach
 
-            val trigger = localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            val trigger = localDateTime.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
 
             alarmScheduler.rescheduleDailyExact(
                 date = sch.date, newTriggerMs = trigger

--- a/feature/sync/build.gradle.kts
+++ b/feature/sync/build.gradle.kts
@@ -19,4 +19,6 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/connect/ConnectViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/connect/ConnectViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.tgyuu.common.base.BaseViewModel
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.model.ErrorBus
 import com.tgyuu.domain.model.Timer
@@ -17,9 +18,13 @@ import com.tgyuu.sync.network.NetworkState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import java.time.Duration
 import java.time.ZonedDateTime
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class ConnectViewModel @Inject constructor(
@@ -39,14 +44,17 @@ class ConnectViewModel @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     internal suspend fun getMyConnectInfo() {
         val myConnectCode = syncRepository.getMyConnectCode()
         val expiration = syncRepository.getConnectCodeExpiration()
 
         if (myConnectCode != null && expiration != null) {
-            val now = ZonedDateTime.now()
-            if (expiration.isAfter(now)) {
-                val remainingSec = Duration.between(now, expiration).seconds
+            val now = LocalDateTime.now()
+            if (expiration > now) {
+                val nowInstant = now.toInstant(TimeZone.currentSystemDefault())
+                val expirationInstant = expiration.toInstant(TimeZone.currentSystemDefault())
+                val remainingSec: Long = (expirationInstant - nowInstant).inWholeSeconds
 
                 setState {
                     copy(

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
@@ -41,7 +41,7 @@ import com.tgyuu.sync.graph.main.contract.SyncMainState
 import com.tgyuu.sync.graph.main.ui.dialog.ConfirmDisconnectDialog
 import com.tgyuu.sync.graph.main.ui.dialog.ConfirmSyncUpDialog
 import kotlinx.coroutines.launch
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 
 @Composable
 internal fun SyncMainRoute(
@@ -249,8 +249,8 @@ private fun TabletSyncMainScreen(
 @Composable
 internal fun UuidBody(
     uuid: String,
-    lastSyncedAt: ZonedDateTime?,
-    lastUpdatedAt: ZonedDateTime?,
+    lastSyncedAt: LocalDateTime?,
+    lastUpdatedAt: LocalDateTime?,
 ) {
     Text(
         text = "해당 디바이스의 고유 ID :",
@@ -278,7 +278,7 @@ internal fun UuidBody(
     )
 
     Text(
-        text = lastSyncedAt?.toLocalDateTime()?.toFormattedString() ?: "기록 없음",
+        text = lastSyncedAt?.toFormattedString() ?: "기록 없음",
         style = EbbingTheme.typography.bodySR,
         color = EbbingTheme.colors.primaryDefault,
         modifier = Modifier
@@ -296,7 +296,7 @@ internal fun UuidBody(
     )
 
     Text(
-        text = lastUpdatedAt?.toLocalDateTime()?.toFormattedString() ?: "기록이 없거나 네트워크가 없음",
+        text = lastUpdatedAt?.toFormattedString() ?: "기록이 없거나 네트워크가 없음",
         style = EbbingTheme.typography.bodySR,
         color = EbbingTheme.colors.primaryDefault,
         modifier = Modifier
@@ -314,8 +314,8 @@ internal fun UuidBody(
 @Composable
 internal fun LinkedUuidBody(
     linkedUuid: String,
-    lastSyncedAt: ZonedDateTime?,
-    lastUpdatedAt: ZonedDateTime?,
+    lastSyncedAt: LocalDateTime?,
+    lastUpdatedAt: LocalDateTime?,
 ) {
     Text(
         text = "연동 되어있는 ID :",
@@ -343,7 +343,7 @@ internal fun LinkedUuidBody(
     )
 
     Text(
-        text = lastSyncedAt?.toLocalDateTime()?.toFormattedString() ?: "기록 없음",
+        text = lastSyncedAt?.toFormattedString() ?: "기록 없음",
         style = EbbingTheme.typography.bodySR,
         color = EbbingTheme.colors.primaryDefault,
         modifier = Modifier
@@ -361,7 +361,7 @@ internal fun LinkedUuidBody(
     )
 
     Text(
-        text = lastUpdatedAt?.toLocalDateTime()?.toFormattedString() ?: "기록이 없거나 네트워크가 없음",
+        text = lastUpdatedAt?.toFormattedString() ?: "기록이 없거나 네트워크가 없음",
         style = EbbingTheme.typography.bodySR,
         color = EbbingTheme.colors.primaryDefault,
         modifier = Modifier

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.tgyuu.common.base.BaseViewModel
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.now
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.model.ErrorBus
 import com.tgyuu.domain.repository.SyncRepository
@@ -18,9 +19,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.time.Duration
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class SyncMainViewModel @Inject constructor(
@@ -31,6 +34,7 @@ class SyncMainViewModel @Inject constructor(
     internal val eventBus: EventBus,
 ) : BaseViewModel<SyncMainState, SyncIntent>(SyncMainState()) {
 
+    @OptIn(ExperimentalTime::class)
     internal suspend fun loadInitData() = coroutineScope {
         val uuidJob = launch {
             val uuid = syncRepository.getUuid()
@@ -51,9 +55,12 @@ class SyncMainViewModel @Inject constructor(
             suspendRunCatching {
                 syncRepository.getServerLastUpdatedAt()
             }.onSuccess { serverLastUpdatedAt ->
+                val now = LocalDateTime.now()
                 val isSyncUpEnabled = serverLastUpdatedAt == null ||
-                        Duration.between(serverLastUpdatedAt, ZonedDateTime.now())
-                            .toMillis() >= SYNC_UP_COOL_TIME
+                        (now.toInstant(TimeZone.currentSystemDefault()) -
+                                serverLastUpdatedAt.toInstant(TimeZone.currentSystemDefault()))
+                            .inWholeMilliseconds >= SYNC_UP_COOL_TIME
+
                 setState {
                     copy(
                         serverLastUpdatedAt = serverLastUpdatedAt,

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/contract/SyncMainState.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/contract/SyncMainState.kt
@@ -1,13 +1,13 @@
 package com.tgyuu.sync.graph.main.contract
 
 import com.tgyuu.common.base.UiState
-import java.time.ZonedDateTime
+import kotlinx.datetime.LocalDateTime
 
 data class SyncMainState(
     val uuid: String = "",
     val linkedUuid: String? = null,
-    val localLastSyncedAt: ZonedDateTime? = null,
-    val serverLastUpdatedAt: ZonedDateTime? = null,
+    val localLastSyncedAt: LocalDateTime? = null,
+    val serverLastUpdatedAt: LocalDateTime? = null,
     val isNetworkLoading: Boolean = true,
     val isSyncUpEnabled: Boolean = true,
 ) : UiState

--- a/feature/tag/build.gradle.kts
+++ b/feature/tag/build.gradle.kts
@@ -19,4 +19,6 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagScreen.kt
+++ b/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.tgyuu.common.now
 import com.tgyuu.common.util.clickable
 import com.tgyuu.designsystem.BasePreview
 import com.tgyuu.designsystem.EbbingPreview
@@ -45,7 +46,7 @@ import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.tag.graph.main.contract.TagIntent
 import com.tgyuu.tag.graph.main.contract.TagState
 import com.tgyuu.tag.graph.main.ui.dialog.DeleteDialog
-import java.time.LocalDate
+import kotlinx.datetime.LocalDate
 
 @Composable
 internal fun TagRoute(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,8 @@ kotlin = "2.1.0"
 kotlinxSerializationJson = "1.8.0"
 # https://github.com/Kotlin/kotlinx.coroutines
 kotlinxCoroutine = "1.10.1"
+# https://github.com/Kotlin/kotlinx-datetime
+kotlinxDatetime = "0.7.1"
 # https://github.com/google/gson
 gson = "2.12.1"
 
@@ -82,6 +84,7 @@ amplitude = "1.16.8"
 ## Accompanist
 # https://github.com/google/accompanist
 accompanist = "0.37.0"
+roomKtx = "2.8.4"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -128,6 +131,8 @@ coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutine" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutine" }
 
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
+
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
@@ -160,6 +165,7 @@ firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore
 firebase-storage = { group = "com.google.firebase", name = "firebase-storage-ktx" }
 
 amplitude-analytics = { module = "com.amplitude:analytics-android", version.ref = "amplitude" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomKtx" }
 
 [bundles]
 


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- java.LocalDateTime ... etc는 JVM 환경에서만 돌아가기 때문에 iOS에서는 호환 X
- 이를 위해 javaDate를 kotlinxDate로 마이그레이션
- Kotlinx.DateTime은 KMP를 지원하기 위해서 컴파일 시점에 각 네이티브에 맞는 코드로 변환됨.