### PR TITLE
[Fix] ClickableText에서 클래스 정보가 노출되던 이슈 해결

### DIFF
--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/OptionsBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/OptionsBottomSheet.kt
@@ -30,7 +30,7 @@ internal fun OptionsBottomSheet(
     ) {
         EbbingBottomSheetHeader(
             title = "편집",
-            subTitle = "${selectedSchedule.title} 일정을 어떻게 할까요?"
+            subTitle = "${selectedSchedule.title.originalText} 일정을 어떻게 할까요?"
         )
 
         Column(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
@@ -15,7 +15,7 @@ internal fun ConfirmDelayDialog(
     EbbingDialog(
         dialogTop = {
             EbbingDialogDefaultTop(
-                title = "${schedule.title} 일정을 하루 미루겠습니까?",
+                title = "${schedule.title.originalText} 일정을 하루 미루겠습니까?",
                 subText = "미룬 일정은 수정하기에서 되돌릴 수 있습니다."
             )
         },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteMemoDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteMemoDialog.kt
@@ -20,7 +20,7 @@ internal fun ConfirmDeleteMemoDialog(
         dialogTop = {
             EbbingDialogDefaultTop(
                 title = buildAnnotatedString {
-                    append("${schedule.title} 일정의 메모를 ")
+                    append("${schedule.title.originalText} 일정의 메모를 ")
                     withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
                         append("삭제")
                     }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteRemainingDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteRemainingDialog.kt
@@ -20,7 +20,7 @@ internal fun ConfirmDeleteRemainingDialog(
         dialogTop = {
             EbbingDialogDefaultTop(
                 title = buildAnnotatedString {
-                    append("${schedule.title} 와 연계된 ${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일 이후 일정을 모두 ")
+                    append("${schedule.title.originalText} 와 연계된 ${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일 이후 일정을 모두 ")
                     withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
                         append("삭제")
                     }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteSingleDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDeleteSingleDialog.kt
@@ -20,7 +20,7 @@ internal fun ConfirmDeleteSingleDialog(
         dialogTop = {
             EbbingDialogDefaultTop(
                 title = buildAnnotatedString {
-                    append("${schedule.title} 일정을 ")
+                    append("${schedule.title.originalText} 일정을 ")
                     withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
                         append("삭제")
                     }


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- ClickableText에서 클래스 정보가 노출되던 이슈 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 옵션 시트, 지연 확인, 메모 삭제, 남은 항목 삭제, 단일 항목 삭제 다이얼로그에서 일정 제목과 부제목이 더 정확하게 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->