### PR TITLE
[Feat] 일정 한번에 미루기 기능 추가

### DIFF
--- a/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
@@ -84,11 +84,13 @@ class TodoRepositoryImpl @Inject constructor(
         tagId: Int,
         dates: List<LocalDate>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek>,
     ) = localTodoDataSource.insertTodos(
         title = title,
         tagId = tagId,
         dates = dates,
         priority = priority,
+        restDays = restDays,
     )
 
     override suspend fun addTodo(
@@ -96,13 +98,15 @@ class TodoRepositoryImpl @Inject constructor(
         tagId: Int,
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
-        priority: Int?
+        priority: Int?,
+        restDays: Set<java.time.DayOfWeek>,
     ) = localTodoDataSource.insertTodos(
         title = title,
         tagId = tagId,
         dates = dates,
         isDoneSchedules = isDoneSchedules,
         priority = priority,
+        restDays = restDays,
     )
 
     override suspend fun addRepeatCycle(intervals: List<Int>): Long {
@@ -124,6 +128,9 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun loadTag(id: Int): TodoTag = localTagDataSource.getTag(id)!!.toDomain()
     override suspend fun loadTodoInfosByTagId(tagId: Int): List<TodoInfo> =
         localTodoDataSource.getTodoInfosByTagId(tagId)
+
+    override suspend fun loadTodoInfoById(infoId: Int): TodoInfo =
+        localTodoDataSource.getTodoInfoById(infoId)
 
     override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) =
         localTodoDataSource.updateTodoInfo(todoSchedule)

--- a/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
@@ -132,8 +132,8 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun loadTodoInfoById(infoId: Int): TodoInfo =
         localTodoDataSource.getTodoInfoById(infoId)
 
-    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) =
-        localTodoDataSource.updateTodoInfo(todoSchedule)
+    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule, restDays: Set<java.time.DayOfWeek>) =
+        localTodoDataSource.updateTodoInfo(todoSchedule, restDays)
 
     override suspend fun updateTodo(todoSchedule: TodoSchedule) =
         localTodoDataSource.updateSchedule(todoSchedule)

--- a/core/database/schemas/com.tgyuu.database.EbbingDatabase/4.json
+++ b/core/database/schemas/com.tgyuu.database.EbbingDatabase/4.json
@@ -1,0 +1,260 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "9d96cc7f809c8f37806ead031c6660da",
+    "entities": [
+      {
+        "tableName": "todo_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `isDeleted` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "schedule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `infoId` INTEGER NOT NULL, `date` TEXT NOT NULL, `memo` TEXT NOT NULL, `priority` INTEGER NOT NULL, `isDone` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `isDeleted` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL, FOREIGN KEY(`infoId`) REFERENCES `todo_info`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "infoId",
+            "columnName": "infoId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memo",
+            "columnName": "memo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDone",
+            "columnName": "isDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_schedule_infoId_date",
+            "unique": false,
+            "columnNames": [
+              "infoId",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_schedule_infoId_date` ON `${TABLE_NAME}` (`infoId`, `date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "todo_info",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "infoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "todo_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `tagId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `rest_days` TEXT NOT NULL, FOREIGN KEY(`tagId`) REFERENCES `todo_tag`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restDays",
+            "columnName": "rest_days",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_todo_info_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_todo_info_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "todo_tag",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "repeat_cycle",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `intervals` TEXT NOT NULL, `isDeleted` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intervals",
+            "columnName": "intervals",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9d96cc7f809c8f37806ead031c6660da')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/com/tgyuu/database/MigrationTest.kt
+++ b/core/database/src/androidTest/java/com/tgyuu/database/MigrationTest.kt
@@ -71,6 +71,65 @@ class MigrationTest {
     }
 
     @Test
+    fun `마이그레이션_3에서4`() {
+        // given: v3 데이터베이스에 TodoInfo 삽입
+        helper.createDatabase(testDbName, 3).apply {
+            execSQL(
+                """
+                INSERT INTO todo_info (id, title, tagId, createdAt, updatedAt)
+                VALUES (1, '테스트 할일', 1, '2024-01-01', '2024-01-01 10:00:00')
+                """.trimIndent()
+            )
+            close()
+        }
+
+        // when: v4로 마이그레이션
+        val db = helper.runMigrationsAndValidate(
+            name = testDbName,
+            version = 4,
+            validateDroppedTables = true,
+            DatabaseMigrations.MIGRATION_3_TO_4
+        )
+
+        // then: rest_days 컬럼 존재 확인 및 기본값 검증
+        val cursor = db.query("SELECT rest_days FROM todo_info WHERE id = 1")
+        cursor.moveToFirst()
+        val restDays = cursor.getString(cursor.getColumnIndexOrThrow("rest_days"))
+        assert(restDays == "") { "기존 데이터의 rest_days는 빈 문자열이어야 합니다" }
+        cursor.close()
+    }
+
+    @Test
+    fun `마이그레이션_3에서4_restDays_저장_테스트`() {
+        // given: v3 데이터베이스
+        helper.createDatabase(testDbName, 3).apply {
+            close()
+        }
+
+        // when: v4로 마이그레이션 후 rest_days 포함 데이터 삽입
+        val db = helper.runMigrationsAndValidate(
+            name = testDbName,
+            version = 4,
+            validateDroppedTables = true,
+            DatabaseMigrations.MIGRATION_3_TO_4
+        )
+
+        db.execSQL(
+            """
+            INSERT INTO todo_info (id, title, tagId, createdAt, updatedAt, rest_days)
+            VALUES (2, '운동', 1, '2024-01-01', '2024-01-01 10:00:00', '3,5')
+            """.trimIndent()
+        )
+
+        // then: rest_days 값 확인
+        val cursor = db.query("SELECT rest_days FROM todo_info WHERE id = 2")
+        cursor.moveToFirst()
+        val restDays = cursor.getString(cursor.getColumnIndexOrThrow("rest_days"))
+        assert(restDays == "3,5") { "rest_days 값이 올바르게 저장되어야 합니다" }
+        cursor.close()
+    }
+
+    @Test
     fun `마이그레이션_1에서3_전체`() {
         helper.createDatabase(testDbName, 1).close()
 
@@ -80,6 +139,20 @@ class MigrationTest {
             validateDroppedTables = true,
             DatabaseMigrations.MIGRATION_1_TO_2,
             DatabaseMigrations.MIGRATION_2_TO_3
+        )
+    }
+
+    @Test
+    fun `마이그레이션_1에서4_전체`() {
+        helper.createDatabase(testDbName, 1).close()
+
+        helper.runMigrationsAndValidate(
+            name = testDbName,
+            version = 4,
+            validateDroppedTables = true,
+            DatabaseMigrations.MIGRATION_1_TO_2,
+            DatabaseMigrations.MIGRATION_2_TO_3,
+            DatabaseMigrations.MIGRATION_3_TO_4
         )
     }
 }

--- a/core/database/src/main/java/com/tgyuu/database/DatabaseMigrations.kt
+++ b/core/database/src/main/java/com/tgyuu/database/DatabaseMigrations.kt
@@ -56,5 +56,14 @@ class DatabaseMigrations {
                 database.execSQL("ALTER TABLE todo_tag ADD COLUMN updatedAt TEXT NOT NULL DEFAULT '1970-01-01T00:00:00'")
             }
         }
+
+        val MIGRATION_3_TO_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // todo_info에 restDays Column 추가
+                database.execSQL(
+                    "ALTER TABLE todo_info ADD COLUMN rest_days TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
     }
 }

--- a/core/database/src/main/java/com/tgyuu/database/EbbingDatabase.kt
+++ b/core/database/src/main/java/com/tgyuu/database/EbbingDatabase.kt
@@ -21,7 +21,7 @@ import com.tgyuu.database.model.TodoTagEntity
         TodoInfoEntity::class,
         RepeatCycleEntity::class,
     ],
-    version = 3,
+    version = 4,
 )
 @TypeConverters(EbbingConverters::class)
 internal abstract class EbbingDatabase : RoomDatabase() {

--- a/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
+++ b/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
@@ -4,6 +4,7 @@ import androidx.room.TypeConverter
 import com.tgyuu.common.toFormattedString
 import com.tgyuu.common.toLocalDateOrThrow
 import com.tgyuu.common.toLocalDateTimeOrThrow
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -41,17 +42,17 @@ class EbbingConverters {
 
     // --- Set<DayOfWeek> ---
     @TypeConverter
-    fun fromRestDays(value: Set<java.time.DayOfWeek>?): String {
+    fun fromRestDays(value: Set<DayOfWeek>?): String {
         return value?.joinToString(",") { it.value.toString() } ?: ""
     }
 
     @TypeConverter
-    fun toRestDays(value: String?): Set<java.time.DayOfWeek> {
+    fun toRestDays(value: String?): Set<DayOfWeek> {
         if (value.isNullOrEmpty()) return emptySet()
         return value.split(",")
-            .mapNotNull { it.toIntOrNull() }
+            .mapNotNull { it.trim().toIntOrNull() }
             .filter { it in 1..7 }
-            .map { java.time.DayOfWeek.of(it) }
+            .map { DayOfWeek.of(it) }
             .toSet()
     }
 }

--- a/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
+++ b/core/database/src/main/java/com/tgyuu/database/converter/EbbingConverters.kt
@@ -38,4 +38,20 @@ class EbbingConverters {
     @TypeConverter
     fun toIntList(data: String?): List<Int> =
         data?.split(",")?.mapNotNull { it.trim().toIntOrNull() } ?: emptyList()
+
+    // --- Set<DayOfWeek> ---
+    @TypeConverter
+    fun fromRestDays(value: Set<java.time.DayOfWeek>?): String {
+        return value?.joinToString(",") { it.value.toString() } ?: ""
+    }
+
+    @TypeConverter
+    fun toRestDays(value: String?): Set<java.time.DayOfWeek> {
+        if (value.isNullOrEmpty()) return emptySet()
+        return value.split(",")
+            .mapNotNull { it.toIntOrNull() }
+            .filter { it in 1..7 }
+            .map { java.time.DayOfWeek.of(it) }
+            .toSet()
+    }
 }

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoSchedulesDao.kt
@@ -212,12 +212,13 @@ interface TodoSchedulesDao {
 
     @Query(
         """
-        SELECT 
+        SELECT
             i.id        AS id,
             i.title     AS title,
             i.tagId     AS tagId,
             i.createdAt AS createdAt,
-            i.updatedAt AS updatedAt
+            i.updatedAt AS updatedAt,
+            i.rest_days AS restDays
         FROM todo_info i
         WHERE i.updatedAt > :lastSyncTime
         """
@@ -226,15 +227,29 @@ interface TodoSchedulesDao {
 
     @Query(
         """
-    SELECT 
+    SELECT
         id,
         title,
-        tagId
+        tagId,
+        rest_days AS restDays
     FROM todo_info
     WHERE tagId = :tagId
     """
     )
     suspend fun loadTodoInfoByTagId(tagId: Int): List<TodoInfo>
+
+    @Query(
+        """
+    SELECT
+        id,
+        title,
+        tagId,
+        rest_days AS restDays
+    FROM todo_info
+    WHERE id = :infoId
+    """
+    )
+    suspend fun getTodoInfoById(infoId: Int): TodoInfo
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertTodoSchedule(todoScheduleEntity: TodoScheduleEntity)

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
@@ -79,7 +79,7 @@ interface TodoWithSchedulesDao {
     @Query(
         """
         UPDATE todo_info
-        SET title = :title, tagId = :tagId, updatedAt = :updatedAt
+        SET title = :title, tagId = :tagId, rest_days = :restDays, updatedAt = :updatedAt
         WHERE id = :id
         """
     )
@@ -87,6 +87,7 @@ interface TodoWithSchedulesDao {
         id: Int,
         title: String,
         tagId: Int,
+        restDays: String = "",
         updatedAt: LocalDateTime = LocalDateTime.now(),
     )
 

--- a/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
+++ b/core/database/src/main/java/com/tgyuu/database/dao/TodoWithSchedulesDao.kt
@@ -24,11 +24,13 @@ interface TodoWithSchedulesDao {
         tagId: Int,
         dates: List<LocalDate>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     ) {
         val infoId = insertInfo(
             TodoInfoEntity(
                 title = title,
                 tagId = tagId,
+                restDays = restDays.joinToString(",") { it.value.toString() },
             )
         ).toInt()
 
@@ -51,11 +53,13 @@ interface TodoWithSchedulesDao {
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     ) {
         val infoId = insertInfo(
             TodoInfoEntity(
                 title = title,
                 tagId = tagId,
+                restDays = restDays.joinToString(",") { it.value.toString() },
             )
         ).toInt()
 

--- a/core/database/src/main/java/com/tgyuu/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/com/tgyuu/database/di/DatabaseModule.kt
@@ -34,6 +34,7 @@ internal object DatabaseProvidesModule {
     )
         .addMigrations(DatabaseMigrations.MIGRATION_1_TO_2)
         .addMigrations(DatabaseMigrations.MIGRATION_2_TO_3)
+        .addMigrations(DatabaseMigrations.MIGRATION_3_TO_4)
         .build()
 }
 

--- a/core/database/src/main/java/com/tgyuu/database/model/TodoInfoEntity.kt
+++ b/core/database/src/main/java/com/tgyuu/database/model/TodoInfoEntity.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.database.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
@@ -26,6 +27,7 @@ data class TodoInfoEntity(
     val tagId: Int,
     val createdAt: LocalDate = LocalDate.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
+    @ColumnInfo(name = "rest_days") val restDays: String = "",
 )
 
 fun TodoInfoForSync.toEntity() = TodoInfoEntity(
@@ -34,4 +36,5 @@ fun TodoInfoForSync.toEntity() = TodoInfoEntity(
     tagId = this.tagId,
     createdAt = this.createdAt,
     updatedAt = this.updatedAt,
+    restDays = this.restDays,
 )

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
@@ -31,6 +31,7 @@ interface LocalTodoDataSource {
         tagId: Int,
         dates: List<LocalDate>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     )
 
     suspend fun insertTodos(
@@ -39,6 +40,7 @@ interface LocalTodoDataSource {
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     )
 
     suspend fun updateTodoInfo(todoSchedule: TodoSchedule)
@@ -56,5 +58,6 @@ interface LocalTodoDataSource {
     suspend fun getSchedulesForSync(lastSyncTime: LocalDateTime): List<TodoScheduleForSync>
     suspend fun getTodoInfosForSync(lastSyncTime: LocalDateTime): List<TodoInfoForSync>
     suspend fun getTodoInfosByTagId(tagId: Int): List<TodoInfo>
+    suspend fun getTodoInfoById(infoId: Int): TodoInfo
     suspend fun deleteAllTodoInfos()
 }

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSource.kt
@@ -43,7 +43,7 @@ interface LocalTodoDataSource {
         restDays: Set<java.time.DayOfWeek> = emptySet(),
     )
 
-    suspend fun updateTodoInfo(todoSchedule: TodoSchedule)
+    suspend fun updateTodoInfo(todoSchedule: TodoSchedule, restDays: Set<java.time.DayOfWeek> = emptySet())
     suspend fun updateTodoInfo(todoInfoForSync: TodoInfoForSync)
     suspend fun updateSchedule(todoSchedule: TodoSchedule)
     suspend fun updateSchedule(todoScheduleForSync: TodoScheduleForSync)

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
@@ -91,11 +91,12 @@ class LocalTodoDataSourceImpl @Inject constructor(
     override suspend fun updateSchedule(todoScheduleForSync: TodoScheduleForSync) =
         todoSchedulesDao.updateTodoSchedule(todoScheduleForSync.toEntity())
 
-    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) =
+    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule, restDays: Set<java.time.DayOfWeek>) =
         todoWithSchedulesDao.updateInfo(
             id = todoSchedule.infoId,
             title = todoSchedule.title,
             tagId = todoSchedule.tagId,
+            restDays = restDays.joinToString(",") { it.value.toString() },
         )
 
     override suspend fun updateTodoInfo(todoInfoForSync: TodoInfoForSync) =

--- a/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/todo/LocalTodoDataSourceImpl.kt
@@ -54,11 +54,13 @@ class LocalTodoDataSourceImpl @Inject constructor(
         tagId: Int,
         dates: List<LocalDate>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek>,
     ) = todoWithSchedulesDao.insertTodoWithSchedules(
         title = title,
         tagId = tagId,
         dates = dates,
         priority = priority,
+        restDays = restDays,
     )
 
     override suspend fun insertTodos(
@@ -66,13 +68,15 @@ class LocalTodoDataSourceImpl @Inject constructor(
         tagId: Int,
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
-        priority: Int?
+        priority: Int?,
+        restDays: Set<java.time.DayOfWeek>,
     ) = todoWithSchedulesDao.insertTodoWithSchedules(
         title = title,
         tagId = tagId,
         dates = dates,
         isDoneSchedules = isDoneSchedules,
         priority = priority,
+        restDays = restDays,
     )
 
     override suspend fun updateSchedule(todoSchedule: TodoSchedule) =
@@ -117,6 +121,9 @@ class LocalTodoDataSourceImpl @Inject constructor(
 
     override suspend fun getTodoInfosByTagId(tagId: Int): List<TodoInfo> =
         todoSchedulesDao.loadTodoInfoByTagId(tagId)
+
+    override suspend fun getTodoInfoById(infoId: Int): TodoInfo =
+        todoSchedulesDao.getTodoInfoById(infoId)
 
     override suspend fun deleteAllTodoInfos() = todoSchedulesDao.hardDeleteAllTodoInfos()
 }

--- a/core/database/src/test/java/com/tgyuu/database/ConvertersTest.kt
+++ b/core/database/src/test/java/com/tgyuu/database/ConvertersTest.kt
@@ -1,0 +1,83 @@
+package com.tgyuu.database
+
+import com.tgyuu.database.converter.EbbingConverters
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+
+class ConvertersTest {
+    private val converters = EbbingConverters()
+
+    @Test
+    fun `빈 Set은 빈 문자열로 변환된다`() {
+        val result = converters.fromRestDays(emptySet())
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `null은 빈 문자열로 변환된다`() {
+        val result = converters.fromRestDays(null)
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `DayOfWeek Set이 쉼표로 구분된 문자열로 변환된다`() {
+        val restDays = setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)
+        val result = converters.fromRestDays(restDays)
+
+        // Set은 순서 보장 안하므로 split 후 비교
+        val numbers = result.split(",").map { it.toInt() }.sorted()
+        assertEquals(listOf(1, 3, 5), numbers)
+    }
+
+    @Test
+    fun `빈 문자열은 빈 Set으로 변환된다`() {
+        val result = converters.toRestDays("")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `null 문자열은 빈 Set으로 변환된다`() {
+        val result = converters.toRestDays(null)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `쉼표로 구분된 문자열이 DayOfWeek Set으로 변환된다`() {
+        val result = converters.toRestDays("1,3,5")
+
+        assertEquals(3, result.size)
+        assertTrue(result.contains(DayOfWeek.MONDAY))
+        assertTrue(result.contains(DayOfWeek.WEDNESDAY))
+        assertTrue(result.contains(DayOfWeek.FRIDAY))
+    }
+
+    @Test
+    fun `잘못된 형식은 무시하고 유효한 값만 변환된다`() {
+        val result = converters.toRestDays("1,abc,3,999,5")
+
+        assertEquals(3, result.size)
+        assertTrue(result.contains(DayOfWeek.MONDAY))
+        assertTrue(result.contains(DayOfWeek.WEDNESDAY))
+        assertTrue(result.contains(DayOfWeek.FRIDAY))
+    }
+
+    @Test
+    fun `범위 밖 숫자는 무시된다`() {
+        val result = converters.toRestDays("0,1,8,3")
+
+        assertEquals(2, result.size)
+        assertTrue(result.contains(DayOfWeek.MONDAY))
+        assertTrue(result.contains(DayOfWeek.WEDNESDAY))
+    }
+
+    @Test
+    fun `라운드트립 변환이 정상 동작한다`() {
+        val original = setOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY, DayOfWeek.SATURDAY)
+        val serialized = converters.fromRestDays(original)
+        val deserialized = converters.toRestDays(serialized)
+
+        assertEquals(original, deserialized)
+    }
+}

--- a/core/domain/src/main/java/com/tgyuu/domain/model/TodoInfo.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/TodoInfo.kt
@@ -1,7 +1,10 @@
 package com.tgyuu.domain.model
 
+import java.time.DayOfWeek
+
 data class TodoInfo(
     val id: Int,
     val title: String,
     val tagId: Int,
+    val restDays: Set<DayOfWeek> = emptySet(),
 )

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoInfoForSync.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/TodoInfoForSync.kt
@@ -9,4 +9,5 @@ data class TodoInfoForSync(
     val tagId: Int,
     val createdAt: LocalDate,
     val updatedAt: LocalDateTime,
+    val restDays: String = "",
 )

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
@@ -36,6 +36,7 @@ interface TodoRepository {
         tagId: Int,
         dates: List<LocalDate>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     )
 
     suspend fun addTodo(
@@ -44,6 +45,7 @@ interface TodoRepository {
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
         priority: Int?,
+        restDays: Set<java.time.DayOfWeek> = emptySet(),
     )
 
     suspend fun addRepeatCycle(intervals: List<Int>): Long
@@ -54,6 +56,7 @@ interface TodoRepository {
     suspend fun loadSchedule(id: Int): TodoSchedule
     suspend fun loadTag(id: Int): TodoTag
     suspend fun loadTodoInfosByTagId(tagId: Int): List<TodoInfo>
+    suspend fun loadTodoInfoById(infoId: Int): TodoInfo
 
     suspend fun updateTodoInfo(todoSchedule: TodoSchedule)
     suspend fun updateTodo(todoSchedule: TodoSchedule)

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/TodoRepository.kt
@@ -58,7 +58,7 @@ interface TodoRepository {
     suspend fun loadTodoInfosByTagId(tagId: Int): List<TodoInfo>
     suspend fun loadTodoInfoById(infoId: Int): TodoInfo
 
-    suspend fun updateTodoInfo(todoSchedule: TodoSchedule)
+    suspend fun updateTodoInfo(todoSchedule: TodoSchedule, restDays: Set<java.time.DayOfWeek> = emptySet())
     suspend fun updateTodo(todoSchedule: TodoSchedule)
     suspend fun deleteTodo(todoSchedule: TodoSchedule)
     suspend fun deleteTodoByTodoInfo(id: Int)

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/TodoInfoDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/TodoInfoDto.kt
@@ -14,6 +14,7 @@ data class TodoInfoDto(
     val tagId: Int = -1,
     val createdAt: Date = defaultDate,
     val updatedAt: Date = defaultDate,
+    val restDays: String = "",
     @ServerTimestamp var uploadedAt: Date? = null,
 ) {
     fun toDomain() = TodoInfoForSync(
@@ -22,6 +23,7 @@ data class TodoInfoDto(
         tagId = tagId,
         createdAt = createdAt.toLocalDate(),
         updatedAt = updatedAt.toLocalDateTime(),
+        restDays = restDays,
     )
 }
 
@@ -31,4 +33,5 @@ fun TodoInfoForSync.toDto() = TodoInfoDto(
     tagId = tagId,
     createdAt = createdAt.toDate(),
     updatedAt = updatedAt.toDate(),
+    restDays = restDays,
 )

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -229,6 +229,7 @@ class AddTodoViewModel @Inject constructor(
             dates = currentState.schedules,
             tagId = tag.id,
             priority = currentState.priority?.toIntOrNull(),
+            restDays = currentState.restDays.toSet(),
         )
 
         val (hour, minute) = configRepository.getAlarmTime()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
@@ -50,12 +50,15 @@ class EditDateViewModel @Inject constructor(
                 ?: throw IllegalArgumentException("해당 일정의 정보가 없습니다.")
 
             val result = todoRepository.loadSchedulesByTodoInfo(infoId)
+            val todoInfo = todoRepository.loadTodoInfoById(infoId)
+
             result.firstOrNull()?.let {
                 setState {
                     copy(
                         title = it.title,
                         originTagColor = it.color,
                         selectedDate = it.date,
+                        restDays = todoInfo.restDays.toImmutableSet(),
                     )
                 }
             }
@@ -154,6 +157,7 @@ class EditDateViewModel @Inject constructor(
             isDoneSchedules = isDoneSchedules,
             tagId = originSchedules.firstOrNull()?.tagId ?: 0,
             priority = originSchedules.firstOrNull()?.priority,
+            restDays = currentState.restDays.toSet(),
         )
 
         val (hour, minute) = configRepository.getAlarmTime()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
@@ -22,6 +22,7 @@ import com.tgyuu.navigation.NavigationEvent
 import com.tgyuu.navigation.TagGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -49,9 +50,11 @@ class EditTodoViewModel @Inject constructor(
             val originTagDeferred = async { todoRepository.loadTag(originSchedule.tagId) }
             val sameInfoSchedulesDeferred =
                 async { todoRepository.loadSchedulesByTodoInfo(originSchedule.infoId) }
+            val todoInfoDeferred = async { todoRepository.loadTodoInfoById(originSchedule.infoId) }
 
             val originTag = originTagDeferred.await()
             val schedulesByDateMap = sameInfoSchedulesDeferred.await()
+            val todoInfo = todoInfoDeferred.await()
 
             setState {
                 copy(
@@ -64,6 +67,7 @@ class EditTodoViewModel @Inject constructor(
                     title = originSchedule.title,
                     priority = originSchedule.priority.takeIf { it != 0 }?.toString() ?: "",
                     tag = originTag.toUiModel(),
+                    restDays = todoInfo.restDays.toImmutableSet(),
                 )
             }
         }
@@ -166,7 +170,7 @@ class EditTodoViewModel @Inject constructor(
         )
 
         todoRepository.updateTodo(newSchedule)
-        todoRepository.updateTodoInfo(newSchedule)
+        todoRepository.updateTodoInfo(newSchedule, currentState.restDays.toSet())
         val (hour, minute) = configRepository.getAlarmTime()
 
         currentState.originSchedule?.date?.let { originDate ->

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.tgyuu.analytics.AnalyticsEvent
+import com.tgyuu.analytics.LocalAnalyticsHelper
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.util.throttledClickable
 import com.tgyuu.designsystem.BasePreview
@@ -88,56 +90,12 @@ internal fun HomeRoute(
         }
     }
 
-    if (isShowDialog && dialogType != null) {
-        when (val dt = dialogType) {
-            is ConfirmDeleteSingle -> ConfirmDeleteSingleDialog(
-                schedule = dt.schedule,
-                onDismissRequest = { isShowDialog = false },
-                onDeleteClick = {
-                    isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDeleteSingleClick(dt.schedule))
-                },
-            )
-
-            is ConfirmDeleteRemaining -> ConfirmDeleteRemainingDialog(
-                schedule = dt.schedule,
-                onDismissRequest = { isShowDialog = false },
-                onDeleteClick = {
-                    isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDeleteRemainingClick(dt.schedule))
-                },
-            )
-
-            is DialogType.ConfirmDelay -> ConfirmDelayDialog(
-                schedule = dt.schedule,
-                onDismissRequest = { isShowDialog = false },
-                onDelayClick = {
-                    isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDelaySingleClick(dt.schedule))
-                },
-            )
-
-            is DialogType.ConfirmDelayAll -> ConfirmDelayAllDialog(
-                schedule = dt.schedule,
-                onDismissRequest = { isShowDialog = false },
-                onDelayClick = {
-                    isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDelayAllClick(dt.schedule))
-                },
-            )
-
-            is DialogType.ConfirmDeleteMemo -> ConfirmDeleteMemoDialog(
-                schedule = dt.schedule,
-                onDismissRequest = { isShowDialog = false },
-                onDeleteClick = {
-                    isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDeleteMemoClick(dt.schedule))
-                },
-            )
-
-            else -> Unit
-        }
-    }
+    HandleDialogs(
+        isShowDialog = isShowDialog,
+        dialogType = dialogType,
+        onDismiss = { isShowDialog = false },
+        onIntent = viewModel::onIntent,
+    )
 
     AnimatedVisibility(state.showWidgetNudgeDialog) {
         WidgetNudgeDialog(
@@ -176,14 +134,30 @@ internal fun HomeRoute(
                                             onClickDelaySingle = {
                                                 scope.launch {
                                                     viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                                    dialogType = DialogType.ConfirmDelay(delayedSchedule)
+                                                    val (restDays, expectedDateExcludingRestDays) = viewModel.calculateDelayInfo(
+                                                        delayedSchedule.infoId,
+                                                        delayedSchedule.date
+                                                    )
+                                                    dialogType = DialogType.ConfirmDelay(
+                                                        schedule = delayedSchedule,
+                                                        restDays = restDays,
+                                                        expectedDateExcludingRestDays = expectedDateExcludingRestDays,
+                                                        expectedDateIncludingRestDays = delayedSchedule.date.plusDays(1)
+                                                    )
                                                     isShowDialog = true
                                                 }
                                             },
                                             onClickDelayAll = {
                                                 scope.launch {
                                                     viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                                    dialogType = DialogType.ConfirmDelayAll(delayedSchedule)
+                                                    val (restDays, expectedDateExcludingRestDays) = viewModel.calculateDelayInfo(
+                                                        delayedSchedule.infoId,
+                                                        delayedSchedule.date
+                                                    )
+                                                    dialogType = DialogType.ConfirmDelayAll(
+                                                        schedule = delayedSchedule,
+                                                        restDays = restDays,
+                                                    )
                                                     isShowDialog = true
                                                 }
                                             },
@@ -499,6 +473,93 @@ private fun TabletHomeScreen(
                     .weight(1f)
                     .padding(horizontal = 20.dp),
             )
+        }
+    }
+}
+
+@Composable
+private fun HandleDialogs(
+    isShowDialog: Boolean,
+    dialogType: DialogType?,
+    onDismiss: () -> Unit,
+    onIntent: (HomeIntent) -> Unit,
+) {
+    val analyticsHelper = LocalAnalyticsHelper.current
+
+    LaunchedEffect(dialogType) {
+        if (dialogType != null) {
+            val dialogTypeName = when (dialogType) {
+                is ConfirmDeleteSingle -> "confirm_delete_single"
+                is ConfirmDeleteRemaining -> "confirm_delete_remaining"
+                is DialogType.ConfirmDelay -> "confirm_delay"
+                is DialogType.ConfirmDelayAll -> "confirm_delay_all"
+                is DialogType.ConfirmDeleteMemo -> "confirm_delete_memo"
+            }
+
+            analyticsHelper.logEvent(
+                AnalyticsEvent(
+                    type = AnalyticsEvent.Types.ACTION,
+                    properties = mutableMapOf(
+                        AnalyticsEvent.PropertiesKeys.ACTION_NAME to "show_dialog",
+                        "dialog_type" to dialogTypeName,
+                    )
+                )
+            )
+        }
+    }
+
+    if (isShowDialog && dialogType != null) {
+        when (val dt = dialogType) {
+            is ConfirmDeleteSingle -> ConfirmDeleteSingleDialog(
+                schedule = dt.schedule,
+                onDismissRequest = onDismiss,
+                onDeleteClick = {
+                    onDismiss()
+                    onIntent(HomeIntent.OnDeleteSingleClick(dt.schedule))
+                },
+            )
+
+            is ConfirmDeleteRemaining -> ConfirmDeleteRemainingDialog(
+                schedule = dt.schedule,
+                onDismissRequest = onDismiss,
+                onDeleteClick = {
+                    onDismiss()
+                    onIntent(HomeIntent.OnDeleteRemainingClick(dt.schedule))
+                },
+            )
+
+            is DialogType.ConfirmDelay -> ConfirmDelayDialog(
+                schedule = dt.schedule,
+                restDays = dt.restDays,
+                expectedDateExcludingRestDays = dt.expectedDateExcludingRestDays,
+                expectedDateIncludingRestDays = dt.expectedDateIncludingRestDays,
+                onDismissRequest = onDismiss,
+                onDelayClick = { includeRestDays ->
+                    onDismiss()
+                    onIntent(HomeIntent.OnDelaySingleClick(dt.schedule, includeRestDays))
+                },
+            )
+
+            is DialogType.ConfirmDelayAll -> ConfirmDelayAllDialog(
+                schedule = dt.schedule,
+                restDays = dt.restDays,
+                onDismissRequest = onDismiss,
+                onDelayClick = { includeRestDays ->
+                    onDismiss()
+                    onIntent(HomeIntent.OnDelayAllClick(dt.schedule, includeRestDays))
+                },
+            )
+
+            is DialogType.ConfirmDeleteMemo -> ConfirmDeleteMemoDialog(
+                schedule = dt.schedule,
+                onDismissRequest = onDismiss,
+                onDeleteClick = {
+                    onDismiss()
+                    onIntent(HomeIntent.OnDeleteMemoClick(dt.schedule))
+                },
+            )
+
+            else -> Unit
         }
     }
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -49,10 +49,12 @@ import com.tgyuu.home.graph.main.contract.HomeIntent.OnCheckChanged
 import com.tgyuu.home.graph.main.contract.HomeIntent.OnSortTypeClick
 import com.tgyuu.home.graph.main.contract.HomeState
 import com.tgyuu.home.graph.main.ui.EbbingTodoList
+import com.tgyuu.home.graph.main.ui.bottomsheet.DelayBottomSheet
 import com.tgyuu.home.graph.main.ui.bottomsheet.DeleteBottomSheet
 import com.tgyuu.home.graph.main.ui.bottomsheet.OptionsBottomSheet
 import com.tgyuu.home.graph.main.ui.bottomsheet.SortTypeBottomSheet
 import com.tgyuu.home.graph.main.ui.bottomsheet.UpdateBottomSheet
+import com.tgyuu.home.graph.main.ui.dialog.ConfirmDelayAllDialog
 import com.tgyuu.home.graph.main.ui.dialog.ConfirmDelayDialog
 import com.tgyuu.home.graph.main.ui.dialog.ConfirmDeleteMemoDialog
 import com.tgyuu.home.graph.main.ui.dialog.ConfirmDeleteRemainingDialog
@@ -111,7 +113,16 @@ internal fun HomeRoute(
                 onDismissRequest = { isShowDialog = false },
                 onDelayClick = {
                     isShowDialog = false
-                    viewModel.onIntent(HomeIntent.OnDelayScheduleClick(dt.schedule))
+                    viewModel.onIntent(HomeIntent.OnDelaySingleClick(dt.schedule))
+                },
+            )
+
+            is DialogType.ConfirmDelayAll -> ConfirmDelayAllDialog(
+                schedule = dt.schedule,
+                onDismissRequest = { isShowDialog = false },
+                onDelayClick = {
+                    isShowDialog = false
+                    viewModel.onIntent(HomeIntent.OnDelayAllClick(dt.schedule))
                 },
             )
 
@@ -157,8 +168,28 @@ internal fun HomeRoute(
                         onClickDelay = { delayedSchedule ->
                             scope.launch {
                                 viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                dialogType = DialogType.ConfirmDelay(delayedSchedule)
-                                isShowDialog = true
+                                delay(200L)
+                                viewModel.onIntent(
+                                    HomeIntent.OnDelayScheduleClick {
+                                        DelayBottomSheet(
+                                            selectedSchedule = delayedSchedule,
+                                            onClickDelaySingle = {
+                                                scope.launch {
+                                                    viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
+                                                    dialogType = DialogType.ConfirmDelay(delayedSchedule)
+                                                    isShowDialog = true
+                                                }
+                                            },
+                                            onClickDelayAll = {
+                                                scope.launch {
+                                                    viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
+                                                    dialogType = DialogType.ConfirmDelayAll(delayedSchedule)
+                                                    isShowDialog = true
+                                                }
+                                            },
+                                        )
+                                    }
+                                )
                             }
                         },
                         onClickDelete = { deletedSchedule ->

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -182,15 +182,13 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun onDelaySchedule(schedule: TodoSchedule) {
-        val nextDate = schedule.date.plusDays(1)
-        val alreadyExistsOnNext = currentState
-            .schedulesByDateMap[nextDate]
-            ?.any { it.infoId == schedule.infoId } == true
+        val todoInfo = todoRepository.loadTodoInfoById(schedule.infoId)
+        val restDays = todoInfo.restDays
 
-        if (alreadyExistsOnNext) {
-            eventBus.sendEvent(EbbingEvent.ShowSnackBar("해당 일정은 이미 다음 날에 있습니다."))
-            eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-            return
+        var nextDate = schedule.date.plusDays(1).nextValidDate(restDays)
+
+        while (cachedSchedules.any { it.infoId == schedule.infoId && it.date == nextDate && it.id != schedule.id }) {
+            nextDate = nextDate.plusDays(1).nextValidDate(restDays)
         }
 
         val delayed = schedule.copy(date = nextDate)
@@ -229,6 +227,9 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun onDelayAllSchedules(schedule: TodoSchedule) {
+        val todoInfo = todoRepository.loadTodoInfoById(schedule.infoId)
+        val restDays = todoInfo.restDays
+
         val futureSchedules = todoRepository
             .loadSchedulesByTodoInfo(schedule.infoId)
             .filter { it.date >= schedule.date }
@@ -240,10 +241,18 @@ class HomeViewModel @Inject constructor(
             return
         }
 
+        val updatedDates = mutableMapOf<Int, LocalDate>()
         val (hour, minute) = configRepository.getAlarmTime()
         for (scheduleToDelay in futureSchedules) {
-            val nextDate = scheduleToDelay.date.plusDays(1)
+            var nextDate = scheduleToDelay.date.plusDays(1).nextValidDate(restDays)
+
+            while (updatedDates.values.contains(nextDate) ||
+                   cachedSchedules.any { it.infoId == schedule.infoId && it.date == nextDate && it.id != scheduleToDelay.id }) {
+                nextDate = nextDate.plusDays(1).nextValidDate(restDays)
+            }
+
             val delayed = scheduleToDelay.copy(date = nextDate)
+            updatedDates[scheduleToDelay.id] = nextDate
 
             todoRepository.updateTodo(delayed)
 
@@ -367,4 +376,12 @@ class HomeViewModel @Inject constructor(
         cachedSchedules = (currentMonthSchedules + cachedSchedules)
             .distinctBy { it.id }
     }
+}
+
+private fun LocalDate.nextValidDate(restDays: Set<java.time.DayOfWeek>): LocalDate {
+    var candidate = this
+    while (restDays.contains(candidate.dayOfWeek)) {
+        candidate = candidate.plusDays(1)
+    }
+    return candidate
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -39,7 +39,7 @@ class HomeViewModel @Inject constructor(
     private val todoRepository: TodoRepository,
     private val configRepository: ConfigRepository,
     private val navigationBus: NavigationBus,
-    private val alarmScheduler: AlarmScheduler,
+    private val alarmScheduler: AlarmScheduler?,
     internal val eventBus: EventBus,
 ) : BaseViewModel<HomeState, HomeIntent>(HomeState()) {
     private var currentMonthSchedules: List<TodoSchedule> = emptyList()
@@ -75,7 +75,9 @@ class HomeViewModel @Inject constructor(
                 ShowBottomSheet(intent.content)
             )
 
-            is HomeIntent.OnDelayScheduleClick -> onDelaySchedule(intent.schedule.toDomainModel())
+            is HomeIntent.OnDelayScheduleClick -> eventBus.sendEvent(ShowBottomSheet(intent.content))
+            is HomeIntent.OnDelaySingleClick -> onDelaySchedule(intent.schedule.toDomainModel())
+            is HomeIntent.OnDelayAllClick -> onDelayAllSchedules(intent.schedule.toDomainModel())
             is HomeIntent.OnMemoClick -> onClickMemo(intent.schedule.toDomainModel())
             is HomeIntent.OnSortTypeClick -> eventBus.sendEvent(ShowBottomSheet(intent.content))
             is HomeIntent.OnUpdateSortType -> onUpdateSortType(intent.sortType)
@@ -202,7 +204,7 @@ class HomeViewModel @Inject constructor(
                 .toInstant()
                 .toEpochMilli()
 
-            alarmScheduler.scheduleDailyExact(
+            alarmScheduler?.scheduleDailyExact(
                 date = nextDate,
                 triggerAtMillis = triggerAtMillis
             )
@@ -224,6 +226,60 @@ class HomeViewModel @Inject constructor(
 
         eventBus.sendEvent(EbbingEvent.HideBottomSheet)
         eventBus.sendEvent(EbbingEvent.ShowSnackBar("해당 일정을 다음 날로 미뤘습니다."))
+    }
+
+    private suspend fun onDelayAllSchedules(schedule: TodoSchedule) {
+        val futureSchedules = todoRepository
+            .loadSchedulesByTodoInfo(schedule.infoId)
+            .filter { it.date >= schedule.date }
+            .sortedByDescending { it.date }
+
+        if (futureSchedules.isEmpty()) {
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar("미룰 일정이 없습니다."))
+            eventBus.sendEvent(EbbingEvent.HideBottomSheet)
+            return
+        }
+
+        val (hour, minute) = configRepository.getAlarmTime()
+        for (scheduleToDelay in futureSchedules) {
+            val nextDate = scheduleToDelay.date.plusDays(1)
+            val delayed = scheduleToDelay.copy(date = nextDate)
+
+            todoRepository.updateTodo(delayed)
+
+            if (nextDate.isAfter(LocalDate.now())) {
+                val triggerAtMillis = nextDate
+                    .atTime(LocalTime.of(hour, minute))
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli()
+
+                alarmScheduler?.scheduleDailyExact(
+                    date = nextDate,
+                    triggerAtMillis = triggerAtMillis
+                )
+            }
+
+            currentMonthSchedules = currentMonthSchedules.map {
+                if (it.id == scheduleToDelay.id) delayed else it
+            }
+            cachedSchedules = cachedSchedules.map {
+                if (it.id == scheduleToDelay.id) delayed else it
+            }
+        }
+
+        updateCacheAfterChange()
+        val newByDate = buildByDateMap(cachedSchedules, currentState.sortType)
+        val newByInfo = buildByInfoMap(cachedSchedules)
+        setState {
+            copy(
+                schedulesByDateMap = newByDate,
+                schedulesByTodoInfo = newByInfo
+            )
+        }
+
+        eventBus.sendEvent(EbbingEvent.HideBottomSheet)
+        eventBus.sendEvent(EbbingEvent.ShowSnackBar("${futureSchedules.size}개 일정을 미뤘습니다."))
     }
 
     private suspend fun navigateToUpdateInfo(infoId: Int) {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -2,6 +2,11 @@ package com.tgyuu.home.graph.main
 
 import androidx.lifecycle.viewModelScope
 import com.tgyuu.alarm.AlarmScheduler
+import com.tgyuu.analytics.AnalyticsEvent
+import com.tgyuu.analytics.AnalyticsEvent.PropertiesKeys.ACTION_NAME
+import com.tgyuu.analytics.AnalyticsEvent.PropertiesKeys.ACTION_RESULT
+import com.tgyuu.analytics.AnalyticsEvent.Types.ACTION
+import com.tgyuu.analytics.AnalyticsHelper
 import com.tgyuu.common.base.BaseViewModel
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EbbingEvent.ShowBottomSheet
@@ -29,6 +34,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.launch
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
@@ -40,6 +46,7 @@ class HomeViewModel @Inject constructor(
     private val configRepository: ConfigRepository,
     private val navigationBus: NavigationBus,
     private val alarmScheduler: AlarmScheduler?,
+    private val analyticsHelper: AnalyticsHelper,
     internal val eventBus: EventBus,
 ) : BaseViewModel<HomeState, HomeIntent>(HomeState()) {
     private var currentMonthSchedules: List<TodoSchedule> = emptyList()
@@ -76,8 +83,8 @@ class HomeViewModel @Inject constructor(
             )
 
             is HomeIntent.OnDelayScheduleClick -> eventBus.sendEvent(ShowBottomSheet(intent.content))
-            is HomeIntent.OnDelaySingleClick -> onDelaySchedule(intent.schedule.toDomainModel())
-            is HomeIntent.OnDelayAllClick -> onDelayAllSchedules(intent.schedule.toDomainModel())
+            is HomeIntent.OnDelaySingleClick -> onDelaySchedule(intent.schedule.toDomainModel(), intent.includeRestDays)
+            is HomeIntent.OnDelayAllClick -> onDelayAllSchedules(intent.schedule.toDomainModel(), intent.includeRestDays)
             is HomeIntent.OnMemoClick -> onClickMemo(intent.schedule.toDomainModel())
             is HomeIntent.OnSortTypeClick -> eventBus.sendEvent(ShowBottomSheet(intent.content))
             is HomeIntent.OnUpdateSortType -> onUpdateSortType(intent.sortType)
@@ -181,9 +188,9 @@ class HomeViewModel @Inject constructor(
         eventBus.sendEvent(EbbingEvent.ShowSnackBar("해당 일정 이후 연계된 일정들을 모두 지웠습니다."))
     }
 
-    private suspend fun onDelaySchedule(schedule: TodoSchedule) {
+    private suspend fun onDelaySchedule(schedule: TodoSchedule, includeRestDays: Boolean = false) {
         val todoInfo = todoRepository.loadTodoInfoById(schedule.infoId)
-        val restDays = todoInfo.restDays
+        val restDays = if (includeRestDays) emptySet() else todoInfo.restDays
 
         var nextDate = schedule.date.plusDays(1).nextValidDate(restDays)
 
@@ -194,6 +201,8 @@ class HomeViewModel @Inject constructor(
         val delayed = schedule.copy(date = nextDate)
         todoRepository.updateTodo(delayed)
         val (hour, minute) = configRepository.getAlarmTime()
+
+        alarmScheduler?.cancelDailyExact(schedule.date)
 
         if (nextDate.isAfter(LocalDate.now())) {
             val triggerAtMillis = nextDate
@@ -222,13 +231,28 @@ class HomeViewModel @Inject constructor(
             )
         }
 
+        analyticsHelper.logEvent(
+            AnalyticsEvent(
+                type = ACTION,
+                properties = mutableMapOf(
+                    ACTION_NAME to "delay_single_schedule",
+                    ACTION_RESULT to "success",
+                    "schedule_id" to schedule.id,
+                    "original_date" to schedule.date.toString(),
+                    "next_date" to nextDate.toString(),
+                    "include_rest_days" to includeRestDays,
+                    "rest_days_count" to restDays.size,
+                )
+            )
+        )
+
         eventBus.sendEvent(EbbingEvent.HideBottomSheet)
         eventBus.sendEvent(EbbingEvent.ShowSnackBar("해당 일정을 다음 날로 미뤘습니다."))
     }
 
-    private suspend fun onDelayAllSchedules(schedule: TodoSchedule) {
+    private suspend fun onDelayAllSchedules(schedule: TodoSchedule, includeRestDays: Boolean = false) {
         val todoInfo = todoRepository.loadTodoInfoById(schedule.infoId)
-        val restDays = todoInfo.restDays
+        val restDays = if (includeRestDays) emptySet() else todoInfo.restDays
 
         val futureSchedules = todoRepository
             .loadSchedulesByTodoInfo(schedule.infoId)
@@ -236,6 +260,16 @@ class HomeViewModel @Inject constructor(
             .sortedByDescending { it.date }
 
         if (futureSchedules.isEmpty()) {
+            analyticsHelper.logEvent(
+                AnalyticsEvent(
+                    type = ACTION,
+                    properties = mutableMapOf(
+                        ACTION_NAME to "delay_all_schedules",
+                        ACTION_RESULT to "no_schedules",
+                        "schedule_id" to schedule.id,
+                    )
+                )
+            )
             eventBus.sendEvent(EbbingEvent.ShowSnackBar("미룰 일정이 없습니다."))
             eventBus.sendEvent(EbbingEvent.HideBottomSheet)
             return
@@ -255,6 +289,8 @@ class HomeViewModel @Inject constructor(
             updatedDates[scheduleToDelay.id] = nextDate
 
             todoRepository.updateTodo(delayed)
+
+            alarmScheduler?.cancelDailyExact(scheduleToDelay.date)
 
             if (nextDate.isAfter(LocalDate.now())) {
                 val triggerAtMillis = nextDate
@@ -286,6 +322,20 @@ class HomeViewModel @Inject constructor(
                 schedulesByTodoInfo = newByInfo
             )
         }
+
+        analyticsHelper.logEvent(
+            AnalyticsEvent(
+                type = ACTION,
+                properties = mutableMapOf(
+                    ACTION_NAME to "delay_all_schedules",
+                    ACTION_RESULT to "success",
+                    "schedule_id" to schedule.id,
+                    "schedules_count" to futureSchedules.size,
+                    "include_rest_days" to includeRestDays,
+                    "rest_days_count" to restDays.size,
+                )
+            )
+        )
 
         eventBus.sendEvent(EbbingEvent.HideBottomSheet)
         eventBus.sendEvent(EbbingEvent.ShowSnackBar("${futureSchedules.size}개 일정을 미뤘습니다."))
@@ -376,12 +426,34 @@ class HomeViewModel @Inject constructor(
         cachedSchedules = (currentMonthSchedules + cachedSchedules)
             .distinctBy { it.id }
     }
+
+    suspend fun calculateDelayInfo(infoId: Int, currentDate: LocalDate): Pair<Set<DayOfWeek>, LocalDate> {
+        val todoInfo = todoRepository.loadTodoInfoById(infoId)
+        val restDays = todoInfo.restDays
+
+        var nextDate = currentDate.plusDays(1).nextValidDate(restDays)
+
+        while (cachedSchedules.any { it.infoId == infoId && it.date == nextDate }) {
+            nextDate = nextDate.plusDays(1).nextValidDate(restDays)
+        }
+
+        return restDays to nextDate
+    }
 }
 
-private fun LocalDate.nextValidDate(restDays: Set<java.time.DayOfWeek>): LocalDate {
+private fun LocalDate.nextValidDate(restDays: Set<DayOfWeek>): LocalDate {
+    if (restDays.size >= 7) {
+        throw IllegalStateException("모든 요일을 휴식할 수는 없습니다")
+    }
+
     var candidate = this
+    var attempts = 0
     while (restDays.contains(candidate.dayOfWeek)) {
         candidate = candidate.plusDays(1)
+        attempts++
+        if (attempts > 7) {
+            throw IllegalStateException("유효한 날짜를 찾을 수 없습니다")
+        }
     }
     return candidate
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
@@ -20,8 +20,14 @@ sealed interface HomeIntent : UiIntent {
     data class OnUpdateInfoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnUpdateDateClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnDelayScheduleClick(val content: BottomSheetContent) : HomeIntent
-    data class OnDelaySingleClick(val schedule: TodoScheduleUiModel) : HomeIntent
-    data class OnDelayAllClick(val schedule: TodoScheduleUiModel) : HomeIntent
+    data class OnDelaySingleClick(
+        val schedule: TodoScheduleUiModel,
+        val includeRestDays: Boolean = false,
+    ) : HomeIntent
+    data class OnDelayAllClick(
+        val schedule: TodoScheduleUiModel,
+        val includeRestDays: Boolean = false,
+    ) : HomeIntent
     data class OnMemoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnDeleteMemoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data object OnSyncClick : HomeIntent

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeIntent.kt
@@ -19,7 +19,9 @@ sealed interface HomeIntent : UiIntent {
     data class OnUpdateScheduleClick(val content: BottomSheetContent) : HomeIntent
     data class OnUpdateInfoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnUpdateDateClick(val schedule: TodoScheduleUiModel) : HomeIntent
-    data class OnDelayScheduleClick(val schedule: TodoScheduleUiModel) : HomeIntent
+    data class OnDelayScheduleClick(val content: BottomSheetContent) : HomeIntent
+    data class OnDelaySingleClick(val schedule: TodoScheduleUiModel) : HomeIntent
+    data class OnDelayAllClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnMemoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data class OnDeleteMemoClick(val schedule: TodoScheduleUiModel) : HomeIntent
     data object OnSyncClick : HomeIntent

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/DelayBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/DelayBottomSheet.kt
@@ -1,0 +1,60 @@
+package com.tgyuu.home.graph.main.ui.bottomsheet
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.tgyuu.common.util.clickable
+import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetHeader
+import com.tgyuu.designsystem.foundation.EbbingTheme
+import com.tgyuu.designsystem.model.TodoScheduleUiModel
+
+@Composable
+internal fun DelayBottomSheet(
+    selectedSchedule: TodoScheduleUiModel,
+    onClickDelaySingle: (TodoScheduleUiModel) -> Unit,
+    onClickDelayAll: (TodoScheduleUiModel) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        EbbingBottomSheetHeader(title = "미루기 방법")
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 20.dp, bottom = 8.dp),
+        ) {
+            Text(
+                text = "하루만 미루기",
+                style = EbbingTheme.typography.bodyMM,
+                color = EbbingTheme.colors.black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onClickDelaySingle(selectedSchedule) }
+                    .height(62.dp),
+            )
+
+            Text(
+                text = "이후 일정 모두 미루기",
+                style = EbbingTheme.typography.bodyMM,
+                color = EbbingTheme.colors.black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onClickDelayAll(selectedSchedule) }
+                    .height(62.dp),
+            )
+        }
+    }
+}

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/DelayBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/bottomsheet/DelayBottomSheet.kt
@@ -33,7 +33,7 @@ internal fun DelayBottomSheet(
                 .padding(top = 20.dp, bottom = 8.dp),
         ) {
             Text(
-                text = "하루만 미루기",
+                text = "이 일정만 미루기",
                 style = EbbingTheme.typography.bodyMM,
                 color = EbbingTheme.colors.black,
                 maxLines = 1,

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
@@ -1,42 +1,104 @@
 package com.tgyuu.home.graph.main.ui.dialog
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.tgyuu.designsystem.component.EbbingDialog
 import com.tgyuu.designsystem.component.EbbingDialogBottom
-import com.tgyuu.designsystem.component.EbbingDialogDefaultTop
 import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 internal fun ConfirmDelayAllDialog(
     schedule: TodoScheduleUiModel,
+    restDays: Set<DayOfWeek>,
     onDismissRequest: () -> Unit,
-    onDelayClick: () -> Unit,
+    onDelayClick: (includeRestDays: Boolean) -> Unit,
 ) {
+    var excludeRestDays by remember { mutableStateOf(true) }
+    val restDaysText = if (restDays.isNotEmpty()) {
+        val dayNames = restDays.sortedBy { it.value }
+            .joinToString(", ") { it.getDisplayName(TextStyle.SHORT, Locale.KOREAN) }
+        "쉬는 요일 제외 ($dayNames)"
+    } else {
+        ""
+    }
+
     EbbingDialog(
-        dialogTop = {
-            EbbingDialogDefaultTop(
-                title = buildAnnotatedString {
-                    append("${schedule.title.originalText} 와 연계된 ${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일 이후 일정을 모두 ")
-                    withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
-                        append("미루기")
-                    }
-                    append(" 하시겠습니까?")
-                },
-                subText = "미룬 일정들은 수정하기에서 되돌릴 수 있습니다."
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 20.dp),
+        ) {
+            Text(
+                text = "모든 ${schedule.title.originalText} 일정을\n하루씩 미루시겠습니까?",
+                color = EbbingTheme.colors.black,
+                style = EbbingTheme.typography.headingMSB,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 40.dp),
             )
-        },
-        dialogBottom = {
+
+            if (restDays.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = excludeRestDays,
+                        onCheckedChange = { excludeRestDays = it },
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = EbbingTheme.colors.primaryDefault,
+                            uncheckedColor = EbbingTheme.colors.light1,
+                        )
+                    )
+
+                    Text(
+                        text = restDaysText,
+                        style = EbbingTheme.typography.bodyMR,
+                        color = EbbingTheme.colors.black,
+                    )
+                }
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            Text(
+                text = "미룬 일정은 수정하기에서 다시 되돌릴 수 있습니다.",
+                style = EbbingTheme.typography.bodySR,
+                color = EbbingTheme.colors.dark2,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+
             EbbingDialogBottom(
-                leftButtonText = "뒤로",
+                leftButtonText = "뒤로가기",
                 rightButtonText = "미루기",
                 onLeftButtonClick = onDismissRequest,
-                onRightButtonClick = onDelayClick,
+                onRightButtonClick = { onDelayClick(false) },
             )
-        },
-        onDismissRequest = onDismissRequest,
-    )
+        }
+    }
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
@@ -1,0 +1,42 @@
+package com.tgyuu.home.graph.main.ui.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.tgyuu.designsystem.component.EbbingDialog
+import com.tgyuu.designsystem.component.EbbingDialogBottom
+import com.tgyuu.designsystem.component.EbbingDialogDefaultTop
+import com.tgyuu.designsystem.foundation.EbbingTheme
+import com.tgyuu.designsystem.model.TodoScheduleUiModel
+
+@Composable
+internal fun ConfirmDelayAllDialog(
+    schedule: TodoScheduleUiModel,
+    onDismissRequest: () -> Unit,
+    onDelayClick: () -> Unit,
+) {
+    EbbingDialog(
+        dialogTop = {
+            EbbingDialogDefaultTop(
+                title = buildAnnotatedString {
+                    append("${schedule.title.originalText} 와 연계된 ${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일 이후 일정을 모두 ")
+                    withStyle(style = SpanStyle(color = EbbingTheme.colors.primaryDefault)) {
+                        append("미루기")
+                    }
+                    append(" 하시겠습니까?")
+                },
+                subText = "미룬 일정들은 수정하기에서 되돌릴 수 있습니다."
+            )
+        },
+        dialogBottom = {
+            EbbingDialogBottom(
+                leftButtonText = "뒤로",
+                rightButtonText = "미루기",
+                onLeftButtonClick = onDismissRequest,
+                onRightButtonClick = onDelayClick,
+            )
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
@@ -1,32 +1,137 @@
 package com.tgyuu.home.graph.main.ui.dialog
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.tgyuu.designsystem.component.EbbingDialog
 import com.tgyuu.designsystem.component.EbbingDialogBottom
-import com.tgyuu.designsystem.component.EbbingDialogDefaultTop
+import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 internal fun ConfirmDelayDialog(
     schedule: TodoScheduleUiModel,
+    restDays: Set<DayOfWeek>,
+    expectedDateExcludingRestDays: LocalDate?,
+    expectedDateIncludingRestDays: LocalDate?,
     onDismissRequest: () -> Unit,
-    onDelayClick: () -> Unit,
+    onDelayClick: (includeRestDays: Boolean) -> Unit,
 ) {
-    EbbingDialog(
-        dialogTop = {
-            EbbingDialogDefaultTop(
-                title = "${schedule.title.originalText} 일정을 하루 미루겠습니까?",
-                subText = "미룬 일정은 수정하기에서 되돌릴 수 있습니다."
+    var excludeRestDays by remember { mutableStateOf(true) }
+
+    val displayedExpectedDate = if (excludeRestDays) {
+        expectedDateExcludingRestDays
+    } else {
+        expectedDateIncludingRestDays
+    }
+
+    val dateText = if (displayedExpectedDate != null) {
+        "${schedule.date.monthValue}월 ${schedule.date.dayOfMonth}일(${
+            schedule.date.dayOfWeek.getDisplayName(
+                TextStyle.SHORT, Locale.KOREAN
             )
-        },
-        dialogBottom = {
+        }) → " + "${displayedExpectedDate.monthValue}월 ${displayedExpectedDate.dayOfMonth}일(${
+            displayedExpectedDate.dayOfWeek.getDisplayName(
+                TextStyle.SHORT, Locale.KOREAN
+            )
+        })"
+    } else {
+        ""
+    }
+
+    val restDaysText = if (restDays.isNotEmpty()) {
+        val dayNames = restDays.sortedBy { it.value }
+            .joinToString(", ") { it.getDisplayName(TextStyle.SHORT, Locale.KOREAN) }
+        "쉬는 요일 제외 ($dayNames)"
+    } else {
+        ""
+    }
+
+    EbbingDialog(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 20.dp),
+        ) {
+            Text(
+                text = "${schedule.title.originalText} 일정을 하루 미루시겠습니까?",
+                color = EbbingTheme.colors.black,
+                style = EbbingTheme.typography.headingMSB.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 40.dp),
+            )
+
+            Text(
+                text = dateText,
+                color = EbbingTheme.colors.primaryDefault,
+                style = EbbingTheme.typography.bodyMSB,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+
+            if (restDays.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = excludeRestDays,
+                        onCheckedChange = { excludeRestDays = it },
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = EbbingTheme.colors.primaryDefault,
+                            uncheckedColor = EbbingTheme.colors.light1,
+                        )
+                    )
+
+                    Text(
+                        text = restDaysText,
+                        style = EbbingTheme.typography.bodyMR,
+                        color = EbbingTheme.colors.black,
+                    )
+                }
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            Text(
+                text = "미룬 일정은 수정하기에서 다시 되돌릴 수 있습니다.",
+                style = EbbingTheme.typography.bodySR,
+                textAlign = TextAlign.Center,
+                color = EbbingTheme.colors.dark2,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+
             EbbingDialogBottom(
-                leftButtonText = "뒤로",
+                leftButtonText = "뒤로가기",
                 rightButtonText = "미루기",
                 onLeftButtonClick = onDismissRequest,
-                onRightButtonClick = onDelayClick,
+                onRightButtonClick = { onDelayClick(!excludeRestDays) },
             )
-        },
-        onDismissRequest = onDismissRequest,
-    )
+        }
+    }
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/DialogType.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/DialogType.kt
@@ -1,11 +1,21 @@
 package com.tgyuu.home.graph.main.ui.dialog
 
 import com.tgyuu.designsystem.model.TodoScheduleUiModel
+import java.time.DayOfWeek
+import java.time.LocalDate
 
 sealed class DialogType(open val schedule: TodoScheduleUiModel) {
     data class ConfirmDeleteSingle(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
     data class ConfirmDeleteRemaining(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
-    data class ConfirmDelay(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
-    data class ConfirmDelayAll(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
+    data class ConfirmDelay(
+        override val schedule: TodoScheduleUiModel,
+        val restDays: Set<DayOfWeek> = emptySet(),
+        val expectedDateExcludingRestDays: LocalDate? = null,
+        val expectedDateIncludingRestDays: LocalDate? = null,
+    ) : DialogType(schedule)
+    data class ConfirmDelayAll(
+        override val schedule: TodoScheduleUiModel,
+        val restDays: Set<DayOfWeek> = emptySet(),
+    ) : DialogType(schedule)
     data class ConfirmDeleteMemo(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/DialogType.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/DialogType.kt
@@ -6,5 +6,6 @@ sealed class DialogType(open val schedule: TodoScheduleUiModel) {
     data class ConfirmDeleteSingle(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
     data class ConfirmDeleteRemaining(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
     data class ConfirmDelay(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
+    data class ConfirmDelayAll(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
     data class ConfirmDeleteMemo(override val schedule: TodoScheduleUiModel) : DialogType(schedule)
 }

--- a/feature/home/src/test/java/com/tgyuu/home/fake/FakeConfigRepository.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/fake/FakeConfigRepository.kt
@@ -1,0 +1,87 @@
+package com.tgyuu.home.fake
+
+import com.tgyuu.domain.model.SortType
+import com.tgyuu.domain.model.Theme
+import com.tgyuu.domain.model.UpdateInfo
+import com.tgyuu.domain.repository.ConfigRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeConfigRepository : ConfigRepository {
+    private var sortType: SortType = SortType.CREATED
+    private var alarmHour: Int = 9
+    private var alarmMinute: Int = 0
+    private var alarmMessage: String = ConfigRepository.DEFAULT_ALARM_MESSAGE
+    private var appTheme: Theme = Theme.NORMAL
+    private var widgetTheme: Theme = Theme.NORMAL
+    private var widgetBackgroundAlpha: Float = 1f
+    private var widgetTextAlpha: Float = 1f
+    private var notificationEnabled: Boolean = true
+    private var isFirstAppOpen: Boolean = false
+    private var shouldShowNotificationNudge: Boolean = false
+
+    override fun getAppTheme(): Flow<Theme> = flowOf(appTheme)
+
+    override fun getWidgetTheme(): Flow<Theme> = flowOf(widgetTheme)
+
+    override fun getWidgetBackgroundAlpha(): Flow<Float> = flowOf(widgetBackgroundAlpha)
+
+    override fun getWidgetTextAlpha(): Flow<Float> = flowOf(widgetTextAlpha)
+
+    override suspend fun isFirstAppOpen(): Boolean = isFirstAppOpen
+
+    override suspend fun shouldShowNotificationNudge(): Boolean = shouldShowNotificationNudge
+
+    override suspend fun setSortType(sortType: SortType) {
+        this.sortType = sortType
+    }
+
+    override suspend fun getSortType(): SortType = sortType
+
+    override suspend fun getNotificationEnabled(): Flow<Boolean> = flowOf(notificationEnabled)
+
+    override suspend fun setNotificationEnabled(enabled: Boolean) {
+        this.notificationEnabled = enabled
+    }
+
+    override suspend fun setAppTheme(theme: Theme) {
+        this.appTheme = theme
+    }
+
+    override suspend fun setWidgetTheme(theme: Theme) {
+        this.widgetTheme = theme
+    }
+
+    override suspend fun setWidgetBackgroundAlpha(alpha: Float) {
+        this.widgetBackgroundAlpha = alpha
+    }
+
+    override suspend fun setWidgetTextAlpha(alpha: Float) {
+        this.widgetTextAlpha = alpha
+    }
+
+    override suspend fun updateAlarmTime(hour: String, minute: String) {
+        this.alarmHour = hour.toInt()
+        this.alarmMinute = minute.toInt()
+    }
+
+    override suspend fun getAlarmTime(): Pair<Int, Int> = Pair(alarmHour, alarmMinute)
+
+    override suspend fun updateAlarmMessage(message: String) {
+        this.alarmMessage = message
+    }
+
+    override suspend fun getAlarmMessage(): String = alarmMessage
+
+    override suspend fun getSoftUpdateInfo(): UpdateInfo {
+        return UpdateInfo(minVersion = "1.0.0", noticeMsg = "")
+    }
+
+    override suspend fun getHardUpdateInfo(): UpdateInfo {
+        return UpdateInfo(minVersion = "1.0.0", noticeMsg = "")
+    }
+
+    override suspend fun getClearSyncFlag(): Boolean = false
+
+    override suspend fun markFirstTodoAdded(): Boolean = false
+}

--- a/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
@@ -145,8 +145,15 @@ class FakeTodoRepository : TodoRepository {
         todoInfos[infoId] = existing.copy(restDays = restDays)
     }
 
-    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) {
-        // No-op for testing
+    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule, restDays: Set<DayOfWeek>) {
+        val existing = todoInfos[todoSchedule.infoId]
+        if (existing != null) {
+            todoInfos[todoSchedule.infoId] = existing.copy(
+                title = todoSchedule.title,
+                tagId = todoSchedule.tagId,
+                restDays = restDays
+            )
+        }
     }
 
     override suspend fun updateTodo(todoSchedule: TodoSchedule) {

--- a/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
@@ -1,0 +1,160 @@
+package com.tgyuu.home.fake
+
+import com.tgyuu.domain.model.RepeatCycle
+import com.tgyuu.domain.model.TodoInfo
+import com.tgyuu.domain.model.TodoSchedule
+import com.tgyuu.domain.model.TodoTag
+import com.tgyuu.domain.repository.TodoRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDate
+
+class FakeTodoRepository : TodoRepository {
+    private val schedules = mutableListOf<TodoSchedule>()
+    private val tags = mutableListOf<TodoTag>()
+    private val repeatCycles = mutableListOf<RepeatCycle>()
+
+    override var recentAddedTagId: Long? = null
+    override var recentAddedRepeatCycleId: Long? = null
+
+    fun addSchedules(vararg schedule: TodoSchedule) {
+        schedules.addAll(schedule)
+    }
+
+    fun clearSchedules() {
+        schedules.clear()
+    }
+
+    override suspend fun loadTodoSchedulesByDateRange(
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<TodoSchedule> {
+        return schedules.filter { it.date in startDate..endDate }
+    }
+
+    override suspend fun loadSchedulesByTodoInfo(id: Int): List<TodoSchedule> {
+        return schedules.filter { it.infoId == id }
+    }
+
+    override suspend fun loadSchedulesByDate(date: LocalDate): List<TodoSchedule> {
+        return schedules.filter { it.date == date }
+    }
+
+    override suspend fun loadUpcomingSchedules(date: LocalDate): List<TodoSchedule> {
+        return schedules.filter { it.date >= date }
+    }
+
+    override suspend fun loadAllSchedules(): List<TodoSchedule> {
+        return schedules.toList()
+    }
+
+    override suspend fun loadTags(): List<TodoTag> {
+        return tags.toList()
+    }
+
+    override suspend fun loadRepeatCycle(id: Int): RepeatCycle {
+        return repeatCycles.first { it.id == id }
+    }
+
+    override suspend fun loadRepeatCycles(): List<RepeatCycle> {
+        return repeatCycles.toList()
+    }
+
+    override fun subscribeSchedulesByDate(date: LocalDate): Flow<List<TodoSchedule>> {
+        return flowOf(schedules.filter { it.date == date })
+    }
+
+    override suspend fun addDefaultTag() {
+        // No-op for testing
+    }
+
+    override suspend fun addTag(name: String, color: Int): Long {
+        val id = (tags.maxOfOrNull { it.id } ?: 0) + 1
+        tags.add(TodoTag(id = id, name = name, color = color, createdAt = LocalDate.now()))
+        return id.toLong()
+    }
+
+    override suspend fun addTodo(
+        title: String,
+        tagId: Int,
+        dates: List<LocalDate>,
+        priority: Int?
+    ) {
+        // No-op for testing
+    }
+
+    override suspend fun addTodo(
+        title: String,
+        tagId: Int,
+        dates: List<LocalDate>,
+        isDoneSchedules: List<Boolean>,
+        priority: Int?
+    ) {
+        // No-op for testing
+    }
+
+    override suspend fun addRepeatCycle(intervals: List<Int>): Long {
+        val id = (repeatCycles.maxOfOrNull { it.id } ?: 0) + 1
+        repeatCycles.add(RepeatCycle(id = id, intervals = intervals))
+        return id.toLong()
+    }
+
+    override suspend fun updateRepeatCycle(repeatCycle: RepeatCycle) {
+        val index = repeatCycles.indexOfFirst { it.id == repeatCycle.id }
+        if (index != -1) {
+            repeatCycles[index] = repeatCycle
+        }
+    }
+
+    override suspend fun deleteRepeatCycle(repeatCycle: RepeatCycle) {
+        repeatCycles.removeIf { it.id == repeatCycle.id }
+    }
+
+    override suspend fun loadSchedule(id: Int): TodoSchedule {
+        return schedules.first { it.id == id }
+    }
+
+    override suspend fun loadTag(id: Int): TodoTag {
+        return tags.first { it.id == id }
+    }
+
+    override suspend fun loadTodoInfosByTagId(tagId: Int): List<TodoInfo> {
+        return emptyList() // Not needed for these tests
+    }
+
+    override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) {
+        // No-op for testing
+    }
+
+    override suspend fun updateTodo(todoSchedule: TodoSchedule) {
+        val index = schedules.indexOfFirst { it.id == todoSchedule.id }
+        if (index != -1) {
+            schedules[index] = todoSchedule
+        }
+    }
+
+    override suspend fun deleteTodo(todoSchedule: TodoSchedule) {
+        schedules.removeIf { it.id == todoSchedule.id }
+    }
+
+    override suspend fun deleteTodoByTodoInfo(id: Int) {
+        schedules.removeIf { it.infoId == id }
+    }
+
+    override suspend fun updateTag(todoTag: TodoTag) {
+        val index = tags.indexOfFirst { it.id == todoTag.id }
+        if (index != -1) {
+            tags[index] = todoTag
+        }
+    }
+
+    override suspend fun deleteTag(todoTag: TodoTag) {
+        tags.removeIf { it.id == todoTag.id }
+    }
+
+    override suspend fun clearData() {
+        schedules.clear()
+        tags.clear()
+        repeatCycles.clear()
+    }
+}

--- a/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/fake/FakeTodoRepository.kt
@@ -7,12 +7,14 @@ import com.tgyuu.domain.model.TodoTag
 import com.tgyuu.domain.repository.TodoRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import java.time.DayOfWeek
 import java.time.LocalDate
 
 class FakeTodoRepository : TodoRepository {
     private val schedules = mutableListOf<TodoSchedule>()
     private val tags = mutableListOf<TodoTag>()
     private val repeatCycles = mutableListOf<RepeatCycle>()
+    private val todoInfos = mutableMapOf<Int, TodoInfo>()
 
     override var recentAddedTagId: Long? = null
     override var recentAddedRepeatCycleId: Long? = null
@@ -78,7 +80,8 @@ class FakeTodoRepository : TodoRepository {
         title: String,
         tagId: Int,
         dates: List<LocalDate>,
-        priority: Int?
+        priority: Int?,
+        restDays: Set<DayOfWeek>
     ) {
         // No-op for testing
     }
@@ -88,7 +91,8 @@ class FakeTodoRepository : TodoRepository {
         tagId: Int,
         dates: List<LocalDate>,
         isDoneSchedules: List<Boolean>,
-        priority: Int?
+        priority: Int?,
+        restDays: Set<DayOfWeek>
     ) {
         // No-op for testing
     }
@@ -120,6 +124,25 @@ class FakeTodoRepository : TodoRepository {
 
     override suspend fun loadTodoInfosByTagId(tagId: Int): List<TodoInfo> {
         return emptyList() // Not needed for these tests
+    }
+
+    override suspend fun loadTodoInfoById(infoId: Int): TodoInfo {
+        return todoInfos[infoId] ?: TodoInfo(
+            id = infoId,
+            title = "Test Todo",
+            tagId = 1,
+            restDays = emptySet()
+        )
+    }
+
+    fun setRestDays(infoId: Int, restDays: Set<DayOfWeek>) {
+        val existing = todoInfos[infoId] ?: TodoInfo(
+            id = infoId,
+            title = "Test Todo",
+            tagId = 1,
+            restDays = restDays
+        )
+        todoInfos[infoId] = existing.copy(restDays = restDays)
     }
 
     override suspend fun updateTodoInfo(todoSchedule: TodoSchedule) {

--- a/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
@@ -1,0 +1,181 @@
+package com.tgyuu.home.graph.main
+
+import com.tgyuu.common.event.EventBus
+import com.tgyuu.domain.model.TodoSchedule
+import com.tgyuu.home.fake.FakeConfigRepository
+import com.tgyuu.home.fake.FakeTodoRepository
+import com.tgyuu.home.graph.main.contract.HomeIntent
+import com.tgyuu.home.model.toUiModel
+import com.tgyuu.navigation.NavigationBus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+    private lateinit var viewModel: HomeViewModel
+    private lateinit var todoRepository: FakeTodoRepository
+    private lateinit var configRepository: FakeConfigRepository
+    private lateinit var eventBus: EventBus
+    private lateinit var navigationBus: NavigationBus
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        todoRepository = FakeTodoRepository()
+        configRepository = FakeConfigRepository()
+        eventBus = EventBus()
+        navigationBus = NavigationBus()
+
+        viewModel = HomeViewModel(
+            todoRepository = todoRepository,
+            configRepository = configRepository,
+            navigationBus = navigationBus,
+            alarmScheduler = null,
+            eventBus = eventBus
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `붙어있는 일정들을 함께 미룰 때 뒤에서부터 처리된다`() = runTest {
+        // given: 연속된 3일의 일정 (1/1, 1/2, 1/3)
+        val baseDate = LocalDate.of(2024, 1, 1)
+        val schedule1 = createSchedule(id = 1, infoId = 100, date = baseDate)
+        val schedule2 = createSchedule(id = 2, infoId = 100, date = baseDate.plusDays(1))
+        val schedule3 = createSchedule(id = 3, infoId = 100, date = baseDate.plusDays(2))
+
+        todoRepository.addSchedules(schedule1, schedule2, schedule3)
+
+        // when: 첫 번째 일정(1/1)부터 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule1.toUiModel()))
+
+        // then: 3개 일정이 모두 +1일씩 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(3, updatedSchedules.count {
+            (it.id == 1 && it.date == baseDate.plusDays(1)) ||
+            (it.id == 2 && it.date == baseDate.plusDays(2)) ||
+            (it.id == 3 && it.date == baseDate.plusDays(3))
+        })
+    }
+
+    @Test
+    fun `단일 일정만 있을 때도 정상적으로 미뤄진다`() = runTest {
+        // given: 단일 일정
+        val baseDate = LocalDate.of(2024, 1, 1)
+        val schedule = createSchedule(id = 1, infoId = 100, date = baseDate)
+        todoRepository.addSchedules(schedule)
+
+        // when: 모두 미루기 실행
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule.toUiModel()))
+
+        // then: 1개 일정이 +1일 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(baseDate.plusDays(1), updatedSchedules[0].date)
+    }
+
+    @Test
+    fun `중간 일정부터 미루면 이후 일정만 처리된다`() = runTest {
+        // given: 5개 일정 (1/1, 1/3, 1/5, 1/7, 1/9)
+        val baseDate = LocalDate.of(2024, 1, 1)
+        val schedule1 = createSchedule(id = 1, infoId = 100, date = baseDate)
+        val schedule2 = createSchedule(id = 2, infoId = 100, date = baseDate.plusDays(2))
+        val schedule3 = createSchedule(id = 3, infoId = 100, date = baseDate.plusDays(4))
+        val schedule4 = createSchedule(id = 4, infoId = 100, date = baseDate.plusDays(6))
+        val schedule5 = createSchedule(id = 5, infoId = 100, date = baseDate.plusDays(8))
+
+        todoRepository.addSchedules(schedule1, schedule2, schedule3, schedule4, schedule5)
+
+        // when: 3번째 일정(1/5)부터 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule3.toUiModel()))
+
+        // then: 이전 2개는 그대로, 이후 3개는 +1일씩 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(2, updatedSchedules.count {
+            (it.id == 1 && it.date == baseDate) || (it.id == 2 && it.date == baseDate.plusDays(2))
+        })
+    }
+
+    @Test
+    fun `미래 날짜만 알람이 재스케줄링된다`() = runTest {
+        // given: 과거, 오늘, 미래 일정
+        val yesterday = LocalDate.now().minusDays(1)
+        val today = LocalDate.now()
+        val tomorrow = LocalDate.now().plusDays(1)
+
+        val schedule1 = createSchedule(id = 1, infoId = 100, date = yesterday)
+        val schedule2 = createSchedule(id = 2, infoId = 100, date = today)
+        val schedule3 = createSchedule(id = 3, infoId = 100, date = tomorrow)
+
+        todoRepository.addSchedules(schedule1, schedule2, schedule3)
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule1.toUiModel()))
+
+        // then: 3개 일정이 모두 +1일씩 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(3, updatedSchedules.count {
+            (it.id == 1 && it.date == today) ||
+            (it.id == 2 && it.date == tomorrow) ||
+            (it.id == 3 && it.date == tomorrow.plusDays(1))
+        })
+    }
+
+    @Test
+    fun `여러 날짜가 띄엄띄엄 있어도 모두 미뤄진다`() = runTest {
+        // given: 불규칙한 간격의 일정들
+        val baseDate = LocalDate.of(2024, 1, 1)
+        val schedule1 = createSchedule(id = 1, infoId = 100, date = baseDate)
+        val schedule2 = createSchedule(id = 2, infoId = 100, date = baseDate.plusDays(5))
+        val schedule3 = createSchedule(id = 3, infoId = 100, date = baseDate.plusDays(10))
+
+        todoRepository.addSchedules(schedule1, schedule2, schedule3)
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule1.toUiModel()))
+
+        // then: 3개 일정이 모두 +1일씩 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(3, updatedSchedules.count {
+            (it.id == 1 && it.date == baseDate.plusDays(1)) ||
+            (it.id == 2 && it.date == baseDate.plusDays(6)) ||
+            (it.id == 3 && it.date == baseDate.plusDays(11))
+        })
+    }
+
+    private fun createSchedule(
+        id: Int,
+        infoId: Int,
+        date: LocalDate,
+        title: String = "테스트 일정",
+        isDone: Boolean = false
+    ) = TodoSchedule(
+        id = id,
+        infoId = infoId,
+        title = title,
+        tagId = 1,
+        name = "태그",
+        color = 0xFF0000,
+        date = date,
+        memo = "",
+        priority = 3,
+        isDone = isDone,
+        createdAt = LocalDate.now(),
+        infoCreatedAt = LocalDate.now()
+    )
+}

--- a/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
 import java.time.LocalDate
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -156,6 +157,99 @@ class HomeViewModelTest {
             (it.id == 2 && it.date == baseDate.plusDays(6)) ||
             (it.id == 3 && it.date == baseDate.plusDays(11))
         })
+    }
+
+    @Test
+    fun `쉬는 요일이 있을 때 해당 요일을 건너뛰고 미룬다`() = runTest {
+        // given: 월요일 일정, 쉬는 요일 = 화요일
+        val monday = LocalDate.of(2024, 1, 1)  // 월요일
+        val schedule = createSchedule(id = 1, infoId = 100, date = monday)
+
+        todoRepository.addSchedules(schedule)
+        todoRepository.setRestDays(infoId = 100, restDays = setOf(DayOfWeek.TUESDAY))
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule.toUiModel()))
+
+        // then: 화요일(1/2)을 건너뛰고 수요일(1/3)로 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(monday.plusDays(2), updatedSchedules[0].date)  // 1/3 (수요일)
+    }
+
+    @Test
+    fun `여러 쉬는 요일을 건너뛰고 미룬다`() = runTest {
+        // given: 금요일 일정, 쉬는 요일 = 토요일, 일요일
+        val friday = LocalDate.of(2024, 1, 5)  // 금요일
+        val schedule = createSchedule(id = 1, infoId = 100, date = friday)
+
+        todoRepository.addSchedules(schedule)
+        todoRepository.setRestDays(
+            infoId = 100,
+            restDays = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+        )
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule.toUiModel()))
+
+        // then: 토요일(1/6), 일요일(1/7)을 건너뛰고 월요일(1/8)로 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(friday.plusDays(3), updatedSchedules[0].date)  // 1/8 (월요일)
+    }
+
+    @Test
+    fun `쉬는 요일이 없으면 바로 다음날로 미룬다`() = runTest {
+        // given: 월요일 일정, 쉬는 요일 없음
+        val monday = LocalDate.of(2024, 1, 1)
+        val schedule = createSchedule(id = 1, infoId = 100, date = monday)
+
+        todoRepository.addSchedules(schedule)
+        todoRepository.setRestDays(infoId = 100, restDays = emptySet())
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule.toUiModel()))
+
+        // then: 화요일(1/2)로 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(monday.plusDays(1), updatedSchedules[0].date)
+    }
+
+    @Test
+    fun `연속된 일정을 쉬는 요일 고려해서 모두 미룬다`() = runTest {
+        // given: 월, 화, 수 일정, 쉬는 요일 = 수요일
+        val monday = LocalDate.of(2024, 1, 1)
+        val schedule1 = createSchedule(id = 1, infoId = 100, date = monday)            // 1/1 (월)
+        val schedule2 = createSchedule(id = 2, infoId = 100, date = monday.plusDays(1)) // 1/2 (화)
+        val schedule3 = createSchedule(id = 3, infoId = 100, date = monday.plusDays(2)) // 1/3 (수)
+
+        todoRepository.addSchedules(schedule1, schedule2, schedule3)
+        todoRepository.setRestDays(infoId = 100, restDays = setOf(DayOfWeek.WEDNESDAY))
+
+        // when: 모두 미루기
+        viewModel.onIntent(HomeIntent.OnDelayAllClick(schedule1.toUiModel()))
+
+        // then: 1/3 (수) 일정이 쉬는 요일을 건너뛰고 1/4 (목)로 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules().sortedBy { it.date }
+        assertEquals(monday.plusDays(3), updatedSchedules[1].date)  // 1/4 (목)
+    }
+
+    @Test
+    fun `단일 일정 미루기도 쉬는 요일을 건너뛴다`() = runTest {
+        // given: 월요일 일정, 쉬는 요일 = 화요일, 수요일
+        val monday = LocalDate.of(2024, 1, 1)
+        val schedule = createSchedule(id = 1, infoId = 100, date = monday)
+
+        todoRepository.addSchedules(schedule)
+        todoRepository.setRestDays(
+            infoId = 100,
+            restDays = setOf(DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY)
+        )
+
+        // when: 단일 일정 미루기
+        viewModel.onIntent(HomeIntent.OnDelaySingleClick(schedule.toUiModel()))
+
+        // then: 화요일(1/2), 수요일(1/3)을 건너뛰고 목요일(1/4)로 미뤄짐
+        val updatedSchedules = todoRepository.loadAllSchedules()
+        assertEquals(monday.plusDays(3), updatedSchedules[0].date)  // 1/4 (목요일)
     }
 
     private fun createSchedule(


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- 일정 한번에 미루기 기능 추가

## 2. 🖼️ 스크린샷(선택)

https://github.com/user-attachments/assets/dda8bbf7-f8c5-4966-9e64-4dea5562b595

<img width="1006" height="327" alt="image" src="https://github.com/user-attachments/assets/09d735cd-32a0-44bc-9cd4-f8240351ee6e" />

<img width="412" height="562" alt="image" src="https://github.com/user-attachments/assets/ffe94210-8568-47c4-af2e-34d8dacc0007" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 일정 미루기 UX 개선: 바텀시트에서 "하루만 미루기"/"이후 일정 모두 미루기" 선택 가능, 확인 대화상자에서 휴일(restDays) 제외 여부 선택.
  * 미루기 시 단일/일괄 처리와 예상일(휴일 포함/제외) 계산 및 안내(스낵바 등) 추가.

* **테스트**
  * 휴일과 연속 일정 상황을 포함한 단위/통합 테스트 대거 추가.

* **데이터베이스/마이그레이션**
  * TodoInfo에 restDays 필드 추가, 변환기·마이그레이션 및 스키마 업데이트 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->