### PR TITLE
[Chore] 미루기 Dialog 중앙 정렬해요

### DIFF
--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayAllDialog.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.home.graph.main.ui.dialog
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -62,6 +63,7 @@ internal fun ConfirmDelayAllDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/dialog/ConfirmDelayDialog.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.home.graph.main.ui.dialog
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -95,6 +96,7 @@ internal fun ConfirmDelayDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- 미루기 Dialog 중앙 정렬해요

<img width="1046" height="1394" alt="image" src="https://github.com/user-attachments/assets/9753731d-6749-4e40-b03d-3466157575b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 일정 연기 관련 대화창의 휴무일 선택 항목이 중앙 정렬로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->