### PR TITLE
[Feat] 반복주기에 매일하기 추가

### DIFF
--- a/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
@@ -244,12 +244,18 @@ class MainActivity : ComponentActivity() {
                 eventBus.eventFlow.collect { event ->
                     when (event) {
                         is EbbingEvent.ShowBottomSheet -> scope.launch {
+                            if (bottomSheetState.state.isVisible) {
+                                bottomSheetState.hide()
+                            }
                             bottomSheetState.setBottomSheetContent(event.content)
                             focusManager.clearFocus()
                             bottomSheetState.show()
                         }
 
-                        EbbingEvent.HideBottomSheet -> scope.launch { bottomSheetState.hide() }
+                        EbbingEvent.HideBottomSheet -> scope.launch {
+                            bottomSheetState.hide()
+                            eventBus.notifyBottomSheetHidden()
+                        }
                         is EbbingEvent.ShowSnackBar -> scope.launch {
                             snackBarHostState.currentSnackbarData?.dismiss()
                             snackBarHostState.showSnackbar(event.msg)

--- a/core/common-ui/src/main/java/com/tgyuu/common/event/EventBus.kt
+++ b/core/common-ui/src/main/java/com/tgyuu/common/event/EventBus.kt
@@ -14,8 +14,18 @@ class EventBus @Inject constructor() {
     private val _eventFlow = Channel<EbbingEvent>(BUFFERED)
     val eventFlow = _eventFlow.receiveAsFlow()
 
+    private val _bottomSheetHidden = Channel<Unit>(BUFFERED)
+
     suspend fun sendEvent(event: EbbingEvent) {
         _eventFlow.send(event)
+    }
+
+    suspend fun notifyBottomSheetHidden() {
+        _bottomSheetHidden.send(Unit)
+    }
+
+    suspend fun awaitBottomSheetHidden() {
+        _bottomSheetHidden.receive()
     }
 }
 

--- a/core/common/src/main/java/com/tgyuu/common/DateUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/DateUtil.kt
@@ -70,6 +70,16 @@ fun generateValidSchedules(
     }
 }
 
+fun generateDailySchedules(
+    baseDate: LocalDate,
+    intervals: List<Int>,
+    restDays: Set<DayOfWeek>
+): List<LocalDate> {
+    return intervals
+        .map { interval -> baseDate.plusDays(interval.toLong()) }
+        .filter { date -> date.dayOfWeek !in restDays }
+}
+
 private fun LocalDate.nextValidDate(restDays: Set<DayOfWeek>): LocalDate {
     var date = this
     while (date.dayOfWeek in restDays) {

--- a/core/common/src/test/java/com/tgyuu/common/DateUtilTest.kt
+++ b/core/common/src/test/java/com/tgyuu/common/DateUtilTest.kt
@@ -207,6 +207,120 @@ class LocalDateFormatTest {
         )
     }
 
+    // === 매일하기 (generateDailySchedules) 테스트 ===
+
+    @Test
+    fun `매일하기는 연속된 날짜를 생성한다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20)
+        val intervals = listOf(0, 1, 2, 3, 4)
+        val restDays = emptySet<DayOfWeek>()
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then
+        assertEquals(
+            listOf(
+                LocalDate.of(2025, 7, 20),
+                LocalDate.of(2025, 7, 21),
+                LocalDate.of(2025, 7, 22),
+                LocalDate.of(2025, 7, 23),
+                LocalDate.of(2025, 7, 24),
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `매일하기에서 쉬는날은 미루지 않고 제거한다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val intervals = listOf(0, 1, 2, 3, 4, 5, 6)
+        val restDays = setOf(DayOfWeek.SUNDAY)
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then - 일요일인 7/20, 7/27은 제거됨
+        assertEquals(
+            listOf(
+                LocalDate.of(2025, 7, 21), // 월
+                LocalDate.of(2025, 7, 22), // 화
+                LocalDate.of(2025, 7, 23), // 수
+                LocalDate.of(2025, 7, 24), // 목
+                LocalDate.of(2025, 7, 25), // 금
+                LocalDate.of(2025, 7, 26), // 토
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `매일하기에서 토요일과 일요일을 쉬는날로 설정하면 주말이 모두 제거된다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 21) // 월요일
+        val intervals = (0..13).toList() // 2주
+        val restDays = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then - 14일 중 주말 4일 제거 = 10일
+        assertEquals(10, result.size)
+        result.forEach { date ->
+            assert(date.dayOfWeek != DayOfWeek.SATURDAY && date.dayOfWeek != DayOfWeek.SUNDAY) {
+                "$date 은 주말인데 포함되어 있습니다"
+            }
+        }
+    }
+
+    @Test
+    fun `매일하기에서 쉬는날이 없으면 모든 날짜가 포함된다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20)
+        val intervals = (0..29).toList() // 30일
+        val restDays = emptySet<DayOfWeek>()
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then
+        assertEquals(30, result.size)
+        assertEquals(LocalDate.of(2025, 7, 20), result.first())
+        assertEquals(LocalDate.of(2025, 8, 18), result.last())
+    }
+
+    @Test
+    fun `매일하기에서 당일만 선택하면 하루만 생성된다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20)
+        val intervals = listOf(0)
+        val restDays = emptySet<DayOfWeek>()
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then
+        assertEquals(listOf(LocalDate.of(2025, 7, 20)), result)
+    }
+
+    @Test
+    fun `매일하기에서 당일이 쉬는날이면 빈 리스트를 반환한다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val intervals = listOf(0)
+        val restDays = setOf(DayOfWeek.SUNDAY)
+
+        // when
+        val result = generateDailySchedules(baseDate, intervals, restDays)
+
+        // then
+        assertEquals(emptyList<LocalDate>(), result)
+    }
+
+    // === 기존 generateValidSchedules 테스트 ===
+
     @Test
     fun `반복 주기를 구할 때 중복 방지와 휴일 회피가 동시에 작동한다`() {
         // given

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
@@ -20,6 +20,7 @@ fun EbbingCalendar(
     calendarState: CalendarState,
     schedulesByDateMap: Map<LocalDate, List<TodoScheduleUiModel>>,
     modifier: Modifier = Modifier,
+    showSyncButton: Boolean = true,
     onSelectDate: (LocalDate) -> Unit = {},
     onSyncClick: () -> Unit = {},
 ) {
@@ -50,6 +51,7 @@ fun EbbingCalendar(
                     onSelectDate(LocalDate.now())
                 }
             },
+            showSyncButton = showSyncButton,
             onSyncClick = onSyncClick,
         )
 

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarController.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarController.kt
@@ -29,6 +29,7 @@ internal fun CalendarController(
     currentDate: LocalDate,
     onGotoTodayClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showSyncButton: Boolean = true,
     onSyncClick: () -> Unit = {},
 ) {
     Row(
@@ -59,18 +60,22 @@ internal fun CalendarController(
             color = EbbingTheme.colors.black,
         )
 
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .size(40.dp)
-                .clickable(onClick = onSyncClick),
-        ) {
-            Image(
-                painter = painterResource(R.drawable.ic_link),
-                contentDescription = "데이터 동기화",
-                colorFilter = ColorFilter.tint(EbbingTheme.colors.black),
-                modifier = Modifier.size(28.dp),
-            )
+        if (showSyncButton) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clickable(onClick = onSyncClick),
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.ic_link),
+                    contentDescription = "데이터 동기화",
+                    colorFilter = ColorFilter.tint(EbbingTheme.colors.black),
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+        } else {
+            Spacer(modifier = Modifier.size(40.dp))
         }
     }
 }

--- a/core/domain/src/main/java/com/tgyuu/domain/model/RepeatCycle.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/RepeatCycle.kt
@@ -8,6 +8,8 @@ data class RepeatCycle(
         if (intervals.isEmpty()) return DISPLAY_ERROR
 
         return when {
+            id == DAILY_REPEAT_ID && intervals.size <= 1 -> "매일하기"
+            id == DAILY_REPEAT_ID -> "매일하기 (${intervals.size}일)"
             intervals.size == 1 && intervals.first() == 0 -> "당일만"
             else -> intervals.joinToString(", ") { day ->
                 if (day == 0) "당일" else "${day}일"
@@ -17,12 +19,18 @@ data class RepeatCycle(
 
     companion object {
         const val DISPLAY_ERROR = "올바른 형태로 작성해주세요."
+        const val DAILY_REPEAT_ID = -5
+        const val MAX_DAILY_REPEAT_DAYS = 365
     }
 }
 
 val DefaultRepeatCycles: List<RepeatCycle> = listOf(
     RepeatCycle(
         id = -1,
+        intervals = listOf(0),
+    ),
+    RepeatCycle(
+        id = RepeatCycle.DAILY_REPEAT_ID,
         intervals = listOf(0),
     ),
     RepeatCycle(

--- a/core/domain/src/test/java/com/tgyuu/domain/model/RepeatCycleTest.kt
+++ b/core/domain/src/test/java/com/tgyuu/domain/model/RepeatCycleTest.kt
@@ -1,0 +1,84 @@
+package com.tgyuu.domain.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RepeatCycleTest {
+
+    @Test
+    fun `매일하기 placeholder는 매일하기로 표시된다`() {
+        // given
+        val cycle = RepeatCycle(id = RepeatCycle.DAILY_REPEAT_ID, intervals = listOf(0))
+
+        // when
+        val result = cycle.toDisplayName()
+
+        // then
+        assertEquals("매일하기", result)
+    }
+
+    @Test
+    fun `매일하기에 종료일이 설정되면 일수가 표시된다`() {
+        // given
+        val cycle = RepeatCycle(
+            id = RepeatCycle.DAILY_REPEAT_ID,
+            intervals = (0..6).toList(), // 7일
+        )
+
+        // when
+        val result = cycle.toDisplayName()
+
+        // then
+        assertEquals("매일하기 (7일)", result)
+    }
+
+    @Test
+    fun `매일하기 30일은 올바르게 표시된다`() {
+        // given
+        val cycle = RepeatCycle(
+            id = RepeatCycle.DAILY_REPEAT_ID,
+            intervals = (0..29).toList(),
+        )
+
+        // when
+        val result = cycle.toDisplayName()
+
+        // then
+        assertEquals("매일하기 (30일)", result)
+    }
+
+    @Test
+    fun `DefaultRepeatCycles에서 매일하기는 당일만 다음에 위치한다`() {
+        // given & when
+        val dailyIndex = DefaultRepeatCycles.indexOfFirst { it.id == RepeatCycle.DAILY_REPEAT_ID }
+        val onlyTodayIndex = DefaultRepeatCycles.indexOfFirst { it.id == -1 }
+
+        // then
+        assertTrue(dailyIndex > onlyTodayIndex, "매일하기는 당일만 아래에 있어야 합니다")
+    }
+
+    @Test
+    fun `당일만은 올바르게 표시된다`() {
+        // given
+        val cycle = RepeatCycle(id = -1, intervals = listOf(0))
+
+        // when
+        val result = cycle.toDisplayName()
+
+        // then
+        assertEquals("당일만", result)
+    }
+
+    @Test
+    fun `일반 반복주기는 기존 형식으로 표시된다`() {
+        // given
+        val cycle = RepeatCycle(id = -2, intervals = listOf(0, 1, 7, 15))
+
+        // when
+        val result = cycle.toDisplayName()
+
+        // then
+        assertEquals("당일, 1일, 7일, 15일", result)
+    }
+}

--- a/core/in-app-review/src/main/java/com/tgyuu/inappreview/InAppReviewManager.kt
+++ b/core/in-app-review/src/main/java/com/tgyuu/inappreview/InAppReviewManager.kt
@@ -25,6 +25,10 @@ class InAppReviewManager @Inject constructor(
         }
     }
 
+    fun openPlayStoreForReview() {
+        context.openPlayStore()
+    }
+
     companion object {
         private const val TAG = "InAppReviewManager"
     }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -61,6 +62,7 @@ internal fun AddTodoRoute(
     viewModel: AddTodoViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    var repeatCycleSheetKey by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(viewModel) {
         viewModel.loadNewTag()
@@ -108,12 +110,15 @@ internal fun AddTodoRoute(
                     )
                 },
                 onRepeatCycleDropDownClick = {
+                    repeatCycleSheetKey++
                     viewModel.onIntent(
                         AddTodoIntent.OnRepeatCycleDropDownClick(
                             {
                                 RepeatCycleBottomSheet(
                                     repeatCycleList = state.repeatCycleList,
                                     originRepeatCycle = state.repeatCycle,
+                                    selectedDate = state.selectedDate,
+                                    openKey = repeatCycleSheetKey,
                                     onAddRepeatCycleClick = {
                                         viewModel.onIntent(AddTodoIntent.OnAddRepeatCycleClick)
                                     },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -176,7 +176,7 @@ class AddTodoViewModel @Inject constructor(
 
     private suspend fun onRepeatCycleChange(repeatCycle: RepeatCycleUiModel) {
         eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-
+        eventBus.awaitBottomSheetHidden()
         setState { copy(repeatCycle = repeatCycle) }
     }
 
@@ -324,4 +324,5 @@ class AddTodoViewModel @Inject constructor(
 
         saveTodoAndNavigateHome()
     }
+
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
@@ -2,9 +2,11 @@ package com.tgyuu.home.graph.addtodo.contract
 
 import androidx.compose.runtime.Immutable
 import com.tgyuu.common.base.UiState
+import com.tgyuu.common.generateDailySchedules
 import com.tgyuu.common.generateValidSchedules
 import com.tgyuu.designsystem.model.RepeatCycleUiModel
 import com.tgyuu.designsystem.model.TodoTagUiModel
+import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.repository.ConfigRepository.Companion.DEFAULT_ALARM_MESSAGE
 import com.tgyuu.experiment.domain.model.Experiment.NotificationNudgeText
 import kotlinx.collections.immutable.ImmutableList
@@ -31,11 +33,19 @@ data class AddTodoState(
     val isModified = title.isNotEmpty() || !priority.isNullOrEmpty() || restDays.isNotEmpty()
     val schedules: List<LocalDate>
         get() = repeatCycle?.let {
-            generateValidSchedules(
-                baseDate = selectedDate,
-                intervals = it.intervals.toList(),
-                restDays = restDays.toSet()
-            )
+            if (it.id == RepeatCycle.DAILY_REPEAT_ID) {
+                generateDailySchedules(
+                    baseDate = selectedDate,
+                    intervals = it.intervals.toList(),
+                    restDays = restDays.toSet()
+                )
+            } else {
+                generateValidSchedules(
+                    baseDate = selectedDate,
+                    intervals = it.intervals.toList(),
+                    restDays = restDays.toSet()
+                )
+            }
         } ?: emptyList()
 
     enum class Page {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,6 +55,7 @@ internal fun EditDateRoute(
     viewModel: EditDateViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    var repeatCycleSheetKey by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(viewModel) {
         viewModel.loadNewRepeatCycle()
@@ -78,12 +81,15 @@ internal fun EditDateRoute(
             )
         },
         onRepeatCycleDropDownClick = {
+            repeatCycleSheetKey++
             viewModel.onIntent(
                 EditDateIntent.OnRepeatCycleDropDownClick(
                     {
                         RepeatCycleBottomSheet(
                             repeatCycleList = state.repeatCycleList,
                             originRepeatCycle = state.repeatCycle,
+                            selectedDate = state.selectedDate,
+                            openKey = repeatCycleSheetKey,
                             onAddRepeatCycleClick = {
                                 viewModel.onIntent(EditDateIntent.OnAddRepeatCycleClick)
                             },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
@@ -113,7 +113,7 @@ class EditDateViewModel @Inject constructor(
 
     private suspend fun onRepeatCycleChange(repeatCycle: RepeatCycleUiModel) {
         eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-
+        eventBus.awaitBottomSheetHidden()
         setState { copy(repeatCycle = repeatCycle) }
     }
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
@@ -2,8 +2,10 @@ package com.tgyuu.home.graph.editdate.contract
 
 import androidx.compose.runtime.Immutable
 import com.tgyuu.common.base.UiState
+import com.tgyuu.common.generateDailySchedules
 import com.tgyuu.common.generateValidSchedules
 import com.tgyuu.designsystem.model.RepeatCycleUiModel
+import com.tgyuu.domain.model.RepeatCycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
@@ -22,10 +24,18 @@ data class EditDateState(
 ) : UiState {
     val schedules: List<LocalDate>
         get() = repeatCycle?.let {
-            generateValidSchedules(
-                baseDate = selectedDate,
-                intervals = it.intervals.toList(),
-                restDays = restDays.toSet()
-            )
+            if (it.id == RepeatCycle.DAILY_REPEAT_ID) {
+                generateDailySchedules(
+                    baseDate = selectedDate,
+                    intervals = it.intervals.toList(),
+                    restDays = restDays.toSet()
+                )
+            } else {
+                generateValidSchedules(
+                    baseDate = selectedDate,
+                    intervals = it.intervals.toList(),
+                    restDays = restDays.toSet()
+                )
+            }
         } ?: emptyList()
 }

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -65,7 +65,6 @@ import com.tgyuu.home.graph.main.ui.dialog.DialogType
 import com.tgyuu.home.graph.main.ui.dialog.DialogType.ConfirmDeleteRemaining
 import com.tgyuu.home.graph.main.ui.dialog.DialogType.ConfirmDeleteSingle
 import com.tgyuu.home.graph.main.ui.dialog.WidgetNudgeDialog
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
@@ -126,7 +125,7 @@ internal fun HomeRoute(
                         onClickDelay = { delayedSchedule ->
                             scope.launch {
                                 viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                delay(200L)
+                                viewModel.eventBus.awaitBottomSheetHidden()
                                 viewModel.onIntent(
                                     HomeIntent.OnDelayScheduleClick {
                                         DelayBottomSheet(
@@ -169,7 +168,7 @@ internal fun HomeRoute(
                         onClickDelete = { deletedSchedule ->
                             scope.launch {
                                 viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                delay(200L)
+                                viewModel.eventBus.awaitBottomSheetHidden()
                                 viewModel.onIntent(
                                     HomeIntent.OnDeleteScheduleClick {
                                         DeleteBottomSheet(
@@ -198,7 +197,7 @@ internal fun HomeRoute(
                         onClickUpdate = { updatedSchedule ->
                             scope.launch {
                                 viewModel.eventBus.sendEvent(EbbingEvent.HideBottomSheet)
-                                delay(200L)
+                                viewModel.eventBus.awaitBottomSheetHidden()
                                 viewModel.onIntent(
                                     HomeIntent.OnUpdateScheduleClick {
                                         UpdateBottomSheet(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/Schedule.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/Schedule.kt
@@ -5,7 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,15 +39,16 @@ internal fun ScheduleContent(
                 modifier = Modifier.padding(top = 32.dp),
             )
 
-            Column(
+            LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier
                     .fillMaxWidth()
+                    .heightIn(max = 400.dp)
                     .padding(top = 8.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(EbbingTheme.colors.light3)
             ) {
-                schedules.forEachIndexed { idx, item ->
+                itemsIndexed(schedules) { idx, item ->
                     ScheduleCard(
                         idx = idx + 1,
                         schedule = item,
@@ -113,15 +117,16 @@ internal fun ScheduleCheckContent(
 
             )
 
-            Column(
+            LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier
                     .fillMaxWidth()
+                    .heightIn(max = 400.dp)
                     .padding(top = 8.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(EbbingTheme.colors.light3)
             ) {
-                schedules.forEachIndexed { idx, item ->
+                itemsIndexed(schedules) { idx, item ->
                     ScheduleCheckCard(
                         idx = idx + 1,
                         isChecked = isDoneSchedules[idx],

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/RepeatCycleBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/RepeatCycleBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.home.graph.ui.bottomsheet
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -11,6 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,18 +25,28 @@ import com.tgyuu.common.util.verticalScrollbar
 import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetHeader
 import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetListItemDefault
 import com.tgyuu.designsystem.component.EbbingSolidButton
+import com.tgyuu.designsystem.component.calendar.EbbingCalendar
+import com.tgyuu.designsystem.component.calendar.rememberCalendarState
 import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.RepeatCycleUiModel
+import com.tgyuu.domain.model.RepeatCycle
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @Composable
 internal fun RepeatCycleBottomSheet(
     repeatCycleList: ImmutableList<RepeatCycleUiModel>,
     originRepeatCycle: RepeatCycleUiModel?,
+    selectedDate: LocalDate,
+    openKey: Int,
     updateRepeatCycle: (RepeatCycleUiModel) -> Unit,
     onAddRepeatCycleClick: () -> Unit,
 ) {
-    var newRepeatCycle by remember(originRepeatCycle) { mutableStateOf(originRepeatCycle) }
+    var newRepeatCycle by remember(openKey) { mutableStateOf(originRepeatCycle) }
+    var showEndDatePicker by remember(openKey) { mutableStateOf(false) }
+    var dailyEndDate by remember(openKey) { mutableStateOf<LocalDate?>(null) }
     val listState = rememberLazyListState()
 
     Column(
@@ -43,44 +55,127 @@ internal fun RepeatCycleBottomSheet(
             .padding(horizontal = 20.dp),
     ) {
         EbbingBottomSheetHeader(
-            title = "반복 주기",
+            title = if (showEndDatePicker) "종료일 선택" else "반복 주기",
             rightComponent = {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = null,
-                    tint = EbbingTheme.colors.black,
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clickable { onAddRepeatCycleClick() },
-                )
+                if (!showEndDatePicker) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        tint = EbbingTheme.colors.black,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clickable { onAddRepeatCycleClick() },
+                    )
+                }
             })
 
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(max = 300.dp)
-                .padding(top = 12.dp)
-                .verticalScrollbar(
-                    state = listState,
-                    color = EbbingTheme.colors.light1,
-                ),
-        ) {
-            items(
-                items = repeatCycleList,
-                key = { it.id },
-            ) { cycle ->
-                EbbingBottomSheetListItemDefault(
-                    label = cycle.displayName,
-                    checked = cycle.id == newRepeatCycle?.id,
-                    onChecked = { newRepeatCycle = cycle },
+        AnimatedVisibility(visible = !showEndDatePicker) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+                    .padding(top = 12.dp)
+                    .verticalScrollbar(
+                        state = listState,
+                        color = EbbingTheme.colors.light1,
+                    ),
+            ) {
+                items(
+                    items = repeatCycleList,
+                    key = { it.id },
+                ) { cycle ->
+                    EbbingBottomSheetListItemDefault(
+                        label = cycle.displayName,
+                        checked = cycle.id == newRepeatCycle?.id,
+                        onChecked = {
+                            newRepeatCycle = cycle
+                            if (cycle.id == RepeatCycle.DAILY_REPEAT_ID) {
+                                showEndDatePicker = true
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(visible = showEndDatePicker) {
+            val calendarState = rememberCalendarState(selectedDate)
+
+            Column {
+                Text(
+                    text = "${selectedDate.monthValue}월 ${selectedDate.dayOfMonth}일부터 언제까지 반복할까요?",
+                    style = EbbingTheme.typography.bodyMM,
+                    color = EbbingTheme.colors.dark2,
+                    modifier = Modifier.padding(top = 8.dp),
                 )
+
+                EbbingCalendar(
+                    calendarState = calendarState,
+                    schedulesByDateMap = emptyMap(),
+                    showSyncButton = false,
+                    onSelectDate = { date ->
+                        if (!date.isBefore(selectedDate)) {
+                            dailyEndDate = date
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                )
+
+                val dayCount = dailyEndDate?.let {
+                    ChronoUnit.DAYS.between(selectedDate, it).toInt()
+                }
+                val exceedsMax = dayCount != null && dayCount > RepeatCycle.MAX_DAILY_REPEAT_DAYS
+
+                if (exceedsMax) {
+                    Text(
+                        text = "최대 ${RepeatCycle.MAX_DAILY_REPEAT_DAYS}일까지 설정할 수 있습니다",
+                        style = EbbingTheme.typography.bodySM,
+                        color = EbbingTheme.colors.error,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                } else if (dayCount != null) {
+                    Text(
+                        text = "총 ${dayCount + 1}일간 매일 반복",
+                        style = EbbingTheme.typography.bodySM,
+                        color = EbbingTheme.colors.primaryDefault,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
             }
         }
 
         EbbingSolidButton(
-            label = "적용하기",
-            onClick = { newRepeatCycle?.let { updateRepeatCycle(it) } },
+            label = if (showEndDatePicker) "적용하기" else "적용하기",
+            enabled = if (showEndDatePicker) {
+                val dayCount = dailyEndDate?.let {
+                    ChronoUnit.DAYS.between(selectedDate, it).toInt()
+                }
+                dayCount != null && dayCount >= 0 && dayCount <= RepeatCycle.MAX_DAILY_REPEAT_DAYS
+            } else true,
+            onClick = {
+                if (showEndDatePicker) {
+                    dailyEndDate?.let { endDate ->
+                        val dayCount = ChronoUnit.DAYS.between(selectedDate, endDate).toInt()
+                        val intervals = (0..dayCount).toList()
+                        val endDateText = if (endDate.year != selectedDate.year) {
+                            "${endDate.year}년 ${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+                        } else {
+                            "${endDate.monthValue}월 ${endDate.dayOfMonth}일"
+                        }
+                        val dailyCycle = RepeatCycleUiModel(
+                            id = RepeatCycle.DAILY_REPEAT_ID,
+                            intervals = intervals.toImmutableList(),
+                            displayName = "매일하기 ($endDateText 까지)",
+                        )
+                        updateRepeatCycle(dailyCycle)
+                    }
+                } else {
+                    newRepeatCycle?.let { updateRepeatCycle(it) }
+                }
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp, bottom = 10.dp),

--- a/feature/home/src/test/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
@@ -1,9 +1,14 @@
 package com.tgyuu.home.graph.addtodo.contract
 
+import com.tgyuu.designsystem.model.RepeatCycleUiModel
+import com.tgyuu.domain.model.RepeatCycle
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toImmutableList
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
+import java.time.LocalDate
 
 class EditDateStateTest {
     @Test
@@ -57,5 +62,81 @@ class EditDateStateTest {
         // then
         val expected = false
         assertEquals(expected, actual)
+    }
+
+    // === 매일하기 스케줄 생성 테스트 ===
+
+    @Test
+    fun `매일하기 선택 시 연속된 일정이 생성된다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 21) // 월요일
+        val intervals = (0..4).toList()
+        val state = AddTodoState(
+            selectedDate = baseDate,
+            repeatCycle = RepeatCycleUiModel(
+                id = RepeatCycle.DAILY_REPEAT_ID,
+                intervals = intervals.toImmutableList(),
+                displayName = "매일하기 (5일)",
+            ),
+        )
+
+        // when
+        val schedules = state.schedules
+
+        // then
+        assertEquals(5, schedules.size)
+        assertEquals(LocalDate.of(2025, 7, 21), schedules.first())
+        assertEquals(LocalDate.of(2025, 7, 25), schedules.last())
+    }
+
+    @Test
+    fun `매일하기에서 쉬는날은 미루지 않고 제거된다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 21) // 월요일
+        val intervals = (0..6).toList() // 월~일 7일
+        val state = AddTodoState(
+            selectedDate = baseDate,
+            repeatCycle = RepeatCycleUiModel(
+                id = RepeatCycle.DAILY_REPEAT_ID,
+                intervals = intervals.toImmutableList(),
+                displayName = "매일하기 (7일)",
+            ),
+            restDays = persistentSetOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
+        )
+
+        // when
+        val schedules = state.schedules
+
+        // then - 7일 중 주말 2일 제거 = 5일
+        assertEquals(5, schedules.size)
+        schedules.forEach { date ->
+            assertTrue(
+                date.dayOfWeek != DayOfWeek.SATURDAY && date.dayOfWeek != DayOfWeek.SUNDAY,
+                "$date 은 주말인데 포함되어 있습니다"
+            )
+        }
+    }
+
+    @Test
+    fun `일반 반복주기에서 쉬는날은 다음 평일로 미뤄진다`() {
+        // given
+        val baseDate = LocalDate.of(2025, 7, 20) // 일요일
+        val intervals = listOf(0, 1, 2)
+        val state = AddTodoState(
+            selectedDate = baseDate,
+            repeatCycle = RepeatCycleUiModel(
+                id = -2,
+                intervals = intervals.toImmutableList(),
+                displayName = "당일, 1일, 2일",
+            ),
+            restDays = persistentSetOf(DayOfWeek.SUNDAY),
+        )
+
+        // when
+        val schedules = state.schedules
+
+        // then - 일요일이 미뤄져서 3개 모두 포함
+        assertEquals(3, schedules.size)
+        assertEquals(LocalDate.of(2025, 7, 21), schedules[0]) // 일→월로 미뤄짐
     }
 }

--- a/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/main/HomeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.home.graph.main
 
+import com.tgyuu.analytics.NoOpAnalyticsHelper
 import com.tgyuu.common.event.EventBus
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.home.fake.FakeConfigRepository
@@ -44,7 +45,8 @@ class HomeViewModelTest {
             configRepository = configRepository,
             navigationBus = navigationBus,
             alarmScheduler = null,
-            eventBus = eventBus
+            analyticsHelper = NoOpAnalyticsHelper(),
+            eventBus = eventBus,
         )
     }
 

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
@@ -83,7 +83,8 @@ internal fun SettingRoute(
                     if (activity != null) {
                         viewModel.inAppReviewManager.requestAndLaunchReview(activity)
                     } else {
-                        viewModel.inAppReviewManager.openPlayStoreForReview()
+                        viewModel.inAppReviewManager.
+                        openPlayStoreForReview()
                     }
                 }
                 is SettingSideEffect.RequestInAppUpdate -> {


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- 반복주기에 매일하기 추가

## 2. 🖼️ 스크린샷(선택)

<img width="599" height="305" alt="image" src="https://github.com/user-attachments/assets/45ba51ca-957c-4741-babf-6dfae743b723" />

https://github.com/user-attachments/assets/093a358f-42c1-447e-8853-aa25b921cacd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 매일 반복하기 기능 추가로 일정을 매일 반복 설정할 때 종료일을 선택할 수 있습니다.
  * 캘린더의 동기화 버튼 표시 여부를 조정할 수 있습니다.

* **Bug Fixes**
  * 일정 목록 렌더링 성능 개선으로 더 빠른 화면 로딩을 경험합니다.
  * 바닥시트 상태 관리 개선으로 UI 전환이 더 안정적입니다.

* **Chores**
  * 설정 화면에서 Google Play 스토어 리뷰 요청 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->