### PR TITLE
[Feat] 달력 월/일 시작 요일 토글 기능 추가

### DIFF
--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -46,6 +46,7 @@ import com.google.gson.reflect.TypeToken
 import com.tgyuu.designsystem.component.calendar.CalendarDate
 import com.tgyuu.designsystem.component.calendar.EbbingDayOfWeek
 import com.tgyuu.designsystem.component.calendar.getCalendarDates
+import com.tgyuu.designsystem.component.calendar.getEbbingDayOfWeek
 import com.tgyuu.designsystem.component.calendar.toKorean
 import com.tgyuu.domain.model.Theme
 import com.tgyuu.domain.model.TodoSchedule
@@ -56,6 +57,7 @@ import com.tgyuu.ebbingplanner.widget.designsystem.foundation.BACKGROUND_ALPHA
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.EbbingWidgetTheme
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.TEXT_ALPHA
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.THEME
+import com.tgyuu.ebbingplanner.widget.designsystem.foundation.WIDGET_MONDAY_START
 import com.tgyuu.ebbingplanner.widget.todaytodo.TodoItemRow
 import com.tgyuu.ebbingplanner.widget.util.ADD_TODO
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
@@ -81,8 +83,10 @@ class CalendarWidget : GlanceAppWidget() {
             val schedulesByDateMap: Map<LocalDate, List<TodoSchedule>> =
                 GsonProvider.gson.fromJson(rawJson, type)
 
+            val mondayStart: Boolean = prefs[WIDGET_MONDAY_START] ?: false
+
             val today = LocalDate.now()
-            val calendarDates = getCalendarDates(today)
+            val calendarDates = getCalendarDates(today, mondayStart)
 
             val selectedDateString = prefs[SELECTED_DATE]
             val selectedDate = selectedDateString?.let { LocalDate.parse(it) } ?: today
@@ -96,6 +100,7 @@ class CalendarWidget : GlanceAppWidget() {
                     schedulesByDateMap = schedulesByDateMap,
                     selectedDate = selectedDate,
                     calendarDates = calendarDates,
+                    mondayStart = mondayStart,
                 )
             }
         }
@@ -108,6 +113,7 @@ private fun CalendarWidgetContent(
     schedulesByDateMap: Map<LocalDate, List<TodoSchedule>>,
     calendarDates: List<CalendarDate>,
     selectedDate: LocalDate,
+    mondayStart: Boolean,
 ) {
     val selectedDateTodoLists = schedulesByDateMap[selectedDate] ?: emptyList()
     val todoListsDoneSize = selectedDateTodoLists.filter { it.isDone }.size
@@ -128,7 +134,7 @@ private fun CalendarWidgetContent(
             )
             .padding(4.dp)
     ) {
-        CalendarWidgetHeader()
+        CalendarWidgetHeader(mondayStart = mondayStart)
 
         CalendarWidgetBody(
             calendarDates = calendarDates,
@@ -147,7 +153,7 @@ private fun CalendarWidgetContent(
 }
 
 @Composable
-private fun CalendarWidgetHeader() {
+private fun CalendarWidgetHeader(mondayStart: Boolean) {
     val today = LocalDate.now()
     Column(modifier = GlanceModifier.fillMaxWidth()) {
         Row(
@@ -184,7 +190,7 @@ private fun CalendarWidgetHeader() {
         }
 
         Row(modifier = GlanceModifier.fillMaxWidth()) {
-            EbbingDayOfWeek.forEach {
+            getEbbingDayOfWeek(mondayStart).forEach {
                 Text(
                     text = it.toKorean(),
                     style = TextStyle(

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -17,6 +17,7 @@ import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.BACKGROUND_ALPHA
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.TEXT_ALPHA
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.THEME
+import com.tgyuu.ebbingplanner.widget.designsystem.foundation.WIDGET_MONDAY_START
 import com.tgyuu.ebbingplanner.widget.util.CheckTodoAction
 import com.tgyuu.ebbingplanner.widget.util.CheckTodoAction.Companion.TODO_ID
 import com.tgyuu.analytics.AnalyticsEvent
@@ -97,6 +98,7 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
         val theme = configRepository.getWidgetTheme().firstOrNull() ?: Theme.NORMAL
         val backgroundAlpha = configRepository.getWidgetBackgroundAlpha().firstOrNull() ?: 1f
         val textAlpha = configRepository.getWidgetTextAlpha().firstOrNull() ?: 1f
+        val mondayStart = configRepository.getMondayStart().firstOrNull() ?: false
         val sortType = configRepository.getSortType()
 
         val now = LocalDate.now()
@@ -119,6 +121,7 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
                     this[THEME] = theme.name
                     this[BACKGROUND_ALPHA] = backgroundAlpha
                     this[TEXT_ALPHA] = textAlpha
+                    this[WIDGET_MONDAY_START] = mondayStart
                 }
             }
 

--- a/app/src/main/java/com/tgyuu/ebbingplanner/widget/designsystem/foundation/Theme.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/widget/designsystem/foundation/Theme.kt
@@ -2,6 +2,7 @@ package com.tgyuu.ebbingplanner.widget.designsystem.foundation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceTheme
@@ -113,3 +114,4 @@ fun EbbingWidgetTheme(
 internal val THEME = stringPreferencesKey("theme")
 internal val BACKGROUND_ALPHA = floatPreferencesKey("background_alpha")
 internal val TEXT_ALPHA = floatPreferencesKey("text_alpha")
+internal val WIDGET_MONDAY_START = booleanPreferencesKey("monday_start")

--- a/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
@@ -75,4 +75,9 @@ class ConfigRepositoryImpl @Inject constructor(
 
     override suspend fun markFirstTodoAdded(): Boolean =
         localUserConfigDataSource.markFirstTodoAdded()
+
+    override fun getMondayStart(): Flow<Boolean> = localUserConfigDataSource.mondayStart
+
+    override suspend fun setMondayStart(enabled: Boolean) =
+        localUserConfigDataSource.setMondayStart(enabled)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
@@ -25,4 +25,6 @@ interface LocalUserConfigDataSource {
     suspend fun setWidgetBackgroundAlpha(alpha: Float)
     suspend fun setWidgetTextAlpha(alpha: Float)
     suspend fun markFirstTodoAdded(): Boolean
+    val mondayStart: Flow<Boolean>
+    suspend fun setMondayStart(enabled: Boolean)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
@@ -126,6 +126,14 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         dataStore.edit { prefs -> prefs[WIDGET_TEXT_ALPHA] = alpha }
     }
 
+    override val mondayStart: Flow<Boolean>
+        get() = dataStore.data
+            .map { prefs -> prefs[MONDAY_START] ?: false }
+
+    override suspend fun setMondayStart(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[MONDAY_START] = enabled }
+    }
+
     override suspend fun markFirstTodoAdded(): Boolean {
         var isFirstTime = false
         dataStore.edit { prefs ->
@@ -150,5 +158,6 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         private val WIDGET_BACKGROUND_ALPHA = floatPreferencesKey("WIDGET_BACKGROUND_ALPHA")
         private val WIDGET_TEXT_ALPHA = floatPreferencesKey("WIDGET_TEXT_ALPHA")
         private val HAS_EVER_ADDED_TODO = booleanPreferencesKey("HAS_EVER_ADDED_TODO")
+        private val MONDAY_START = booleanPreferencesKey("MONDAY_START")
     }
 }

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
@@ -21,6 +21,7 @@ fun EbbingCalendar(
     schedulesByDateMap: Map<LocalDate, List<TodoScheduleUiModel>>,
     modifier: Modifier = Modifier,
     showSyncButton: Boolean = true,
+    startFromMonday: Boolean = false,
     onSelectDate: (LocalDate) -> Unit = {},
     onSyncClick: () -> Unit = {},
 ) {
@@ -55,7 +56,7 @@ fun EbbingCalendar(
             onSyncClick = onSyncClick,
         )
 
-        CalendarHeader()
+        CalendarHeader(startFromMonday = startFromMonday)
 
         HorizontalPager(
             state = pagerState,
@@ -65,6 +66,7 @@ fun EbbingCalendar(
                 currentDate = calendarState.currentDisplayDate,
                 selectedDate = calendarState.selectedDate,
                 schedulesByDateMap = schedulesByDateMap,
+                startFromMonday = startFromMonday,
                 onDateSelect = { selectedDate ->
                     val selectedOffset = yearMonthDiff(
                         from = calendarState.originSelectedDate,

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarBody.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarBody.kt
@@ -45,6 +45,7 @@ internal fun CalendarBody(
     selectedDate: LocalDate?,
     schedulesByDateMap: Map<LocalDate, List<TodoScheduleUiModel>>,
     onDateSelect: (LocalDate) -> Unit,
+    startFromMonday: Boolean,
     modifier: Modifier = Modifier,
 ) {
     LazyVerticalGrid(
@@ -53,7 +54,7 @@ internal fun CalendarBody(
         modifier = modifier.semantics { contentDescription = "달력 바디" },
     ) {
         items(
-            items = getCalendarDates(currentDate),
+            items = getCalendarDates(currentDate, startFromMonday),
             key = { it.date },
         ) {
             CalendarDayItem(

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarDate.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarDate.kt
@@ -20,6 +20,10 @@ val EbbingDayOfWeek = listOf(
     SATURDAY,
 )
 
+fun getEbbingDayOfWeek(startFromMonday: Boolean): List<DayOfWeek> =
+    if (startFromMonday) listOf(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
+    else EbbingDayOfWeek
+
 data class CalendarDate(
     val date: LocalDate,
     val isCurrentMonth: Boolean,
@@ -27,20 +31,23 @@ data class CalendarDate(
     val dayOfMonth: Int = date.dayOfMonth
 }
 
-fun getCalendarDates(date: LocalDate): List<CalendarDate> {
-    val previous = getPreviousMonthDatesToShow(date)
+fun getCalendarDates(date: LocalDate, startFromMonday: Boolean = false): List<CalendarDate> {
+    val previous = getPreviousMonthDatesToShow(date, startFromMonday)
     val current = getCurrentMonthDatesToShow(date)
-    val next = getNextMonthDatesToShow(date)
+    val next = getNextMonthDatesToShow(date, startFromMonday)
 
     return previous + current + next
 }
 
-private fun getPreviousMonthDatesToShow(date: LocalDate): List<CalendarDate> {
+private fun getPreviousMonthDatesToShow(
+    date: LocalDate,
+    startFromMonday: Boolean,
+): List<CalendarDate> {
     val firstDayOfMonth = date.withDayOfMonth(1)
     val previousMonth = firstDayOfMonth.minusMonths(1)
     val lastDayOfPreviousMonth = previousMonth.lengthOfMonth()
 
-    val count = getPreviousMonthDayOfWeeksToShow(date).size
+    val count = getPreviousMonthDayOfWeeksToShow(date, startFromMonday).size
 
     return ((lastDayOfPreviousMonth - count + 1)..lastDayOfPreviousMonth).map {
         CalendarDate(previousMonth.withDayOfMonth(it), isCurrentMonth = false)
@@ -55,9 +62,12 @@ private fun getCurrentMonthDatesToShow(date: LocalDate): List<CalendarDate> {
     }
 }
 
-private fun getNextMonthDatesToShow(date: LocalDate): List<CalendarDate> {
+private fun getNextMonthDatesToShow(
+    date: LocalDate,
+    startFromMonday: Boolean,
+): List<CalendarDate> {
     val totalDayCountUntilNextMonth =
-        getPreviousMonthDatesToShow(date).size + getCurrentMonthDatesToShow(date).size
+        getPreviousMonthDatesToShow(date, startFromMonday).size + getCurrentMonthDatesToShow(date).size
     val remainCount = 42 - totalDayCountUntilNextMonth
 
     val nextMonth = date.withDayOfMonth(1).plusMonths(1)
@@ -71,9 +81,16 @@ private fun getNextMonthDatesToShow(date: LocalDate): List<CalendarDate> {
  * 1일 전에 보여야 할 이전 달의 요일 목록을 반환합니다.
  *
  */
-private fun getPreviousMonthDayOfWeeksToShow(date: LocalDate): List<DayOfWeek> {
+private fun getPreviousMonthDayOfWeeksToShow(
+    date: LocalDate,
+    startFromMonday: Boolean,
+): List<DayOfWeek> {
     val firstDayOfWeek = getFirstDayOfWeek(date)
-    val count = (firstDayOfWeek.value % 7) // SUNDAY(7) % 7 = 0 → 일요일 기준
+    val count = if (startFromMonday) {
+        (firstDayOfWeek.value - 1) // MONDAY(1)->0, TUESDAY(2)->1, ..., SUNDAY(7)->6
+    } else {
+        (firstDayOfWeek.value % 7) // SUNDAY(7) % 7 = 0 → 일요일 기준
+    }
 
     return (0 until count).map {
         DayOfWeek.of((it + 1))

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarHeader.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/CalendarHeader.kt
@@ -11,13 +11,16 @@ import androidx.compose.ui.text.style.TextAlign
 import com.tgyuu.designsystem.foundation.EbbingTheme
 
 @Composable
-internal fun CalendarHeader(modifier: Modifier = Modifier) {
+internal fun CalendarHeader(
+    startFromMonday: Boolean,
+    modifier: Modifier = Modifier,
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .semantics { contentDescription = "달력 헤더" },
     ) {
-        EbbingDayOfWeek.forEachIndexed { idx, weekday ->
+        getEbbingDayOfWeek(startFromMonday).forEachIndexed { idx, weekday ->
             val weekDayText = weekday.toKorean()
 
             Text(

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
@@ -29,6 +29,8 @@ interface ConfigRepository {
 
     suspend fun getClearSyncFlag(): Boolean
     suspend fun markFirstTodoAdded(): Boolean
+    fun getMondayStart(): Flow<Boolean>
+    suspend fun setMondayStart(enabled: Boolean)
 
     companion object {
         const val DEFAULT_ALARM_MESSAGE: String = "{할일} 을 확인하고, 잊지 말고 복습하세요!"

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoScreen.kt
@@ -83,6 +83,7 @@ internal fun AddTodoRoute(
                                 SelectedDateBottomSheet(
                                     originSelectedDate = state.selectedDate,
                                     schedulesByDateMap = emptyMap(),
+                                    startFromMonday = state.mondayStart,
                                     updateSelectedDate = {
                                         viewModel.onIntent(
                                             AddTodoIntent.OnSelectedDateChange(it)
@@ -119,6 +120,7 @@ internal fun AddTodoRoute(
                                     originRepeatCycle = state.repeatCycle,
                                     selectedDate = state.selectedDate,
                                     openKey = repeatCycleSheetKey,
+                                    startFromMonday = state.mondayStart,
                                     onAddRepeatCycleClick = {
                                         viewModel.onIntent(AddTodoIntent.OnAddRepeatCycleClick)
                                     },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -58,6 +58,11 @@ class AddTodoViewModel @Inject constructor(
             )
         }
         initNotificationState()
+
+        viewModelScope.launch {
+            configRepository.getMondayStart()
+                .collect { setState { copy(mondayStart = it) } }
+        }
     }
 
     private fun initNotificationState() = viewModelScope.launch {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/contract/AddTodoState.kt
@@ -27,6 +27,7 @@ data class AddTodoState(
     val repeatCycle: RepeatCycleUiModel? = null,
     val restDays: ImmutableSet<DayOfWeek> = persistentSetOf(),
     val notificationState: NotificationState = NotificationState(),
+    val mondayStart: Boolean = false,
 ) : UiState {
     val isSaveEnabled = title.isNotEmpty()
     val isModified = title.isNotEmpty() || !priority.isNullOrEmpty() || restDays.isNotEmpty()

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateScreen.kt
@@ -72,6 +72,7 @@ internal fun EditDateRoute(
                         SelectedDateBottomSheet(
                             originSelectedDate = state.selectedDate,
                             schedulesByDateMap = emptyMap(),
+                            startFromMonday = state.mondayStart,
                             updateSelectedDate = {
                                 viewModel.onIntent(EditDateIntent.OnSelectedDateChange(it))
                             },
@@ -90,6 +91,7 @@ internal fun EditDateRoute(
                             originRepeatCycle = state.repeatCycle,
                             selectedDate = state.selectedDate,
                             openKey = repeatCycleSheetKey,
+                            startFromMonday = state.mondayStart,
                             onAddRepeatCycleClick = {
                                 viewModel.onIntent(EditDateIntent.OnAddRepeatCycleClick)
                             },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
@@ -65,6 +65,11 @@ class EditDateViewModel @Inject constructor(
 
             originSchedules = result
         }
+
+        viewModelScope.launch {
+            configRepository.getMondayStart()
+                .collect { setState { copy(mondayStart = it) } }
+        }
     }
 
     internal fun loadNewRepeatCycle() {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/contract/EditDateState.kt
@@ -21,6 +21,7 @@ data class EditDateState(
     val repeatCycleList: ImmutableList<RepeatCycleUiModel> = persistentListOf(),
     val repeatCycle: RepeatCycleUiModel? = null,
     val restDays: ImmutableSet<DayOfWeek> = persistentSetOf(),
+    val mondayStart: Boolean = false,
 ) : UiState {
     val schedules: List<LocalDate>
         get() = repeatCycle?.let {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoScreen.kt
@@ -63,6 +63,7 @@ internal fun EditTodoRoute(
                         SelectedDateBottomSheet(
                             originSelectedDate = state.selectedDate,
                             schedulesByDateMap = state.schedulesByDateMap,
+                            startFromMonday = state.mondayStart,
                             updateSelectedDate = {
                                 viewModel.onIntent(EditTodoIntent.OnSelectedDateChange(it))
                             },

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
@@ -71,6 +71,11 @@ class EditTodoViewModel @Inject constructor(
                 )
             }
         }
+
+        viewModelScope.launch {
+            configRepository.getMondayStart()
+                .collect { setState { copy(mondayStart = it) } }
+        }
     }
 
     internal fun loadTags() = viewModelScope.launch {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/contract/EditTodoState.kt
@@ -28,6 +28,7 @@ data class EditTodoState(
     val repeatCycleList: ImmutableList<RepeatCycleUiModel> = persistentListOf(),
     val repeatCycle: RepeatCycleUiModel? = null,
     val restDays: ImmutableSet<DayOfWeek> = persistentSetOf(),
+    val mondayStart: Boolean = false,
 ) : UiState {
     val isSaveEnabled = title.isNotEmpty()
     val schedules: List<LocalDate>

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -322,6 +322,7 @@ private fun PhoneHomeScreen(
             EbbingCalendar(
                 calendarState = calendarState,
                 schedulesByDateMap = state.schedulesByDateMap,
+                startFromMonday = state.mondayStart,
                 onSelectDate = {
                     if (selectedDate != it) {
                         scope.launch {
@@ -424,6 +425,7 @@ private fun TabletHomeScreen(
         EbbingCalendar(
             calendarState = calendarState,
             schedulesByDateMap = state.schedulesByDateMap,
+            startFromMonday = state.mondayStart,
             onSelectDate = {
                 if (selectedDate != it) {
                     scope.launch {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -57,6 +57,11 @@ class HomeViewModel @Inject constructor(
             val sortType = configRepository.getSortType()
             setState { copy(sortType = sortType) }
         }
+
+        viewModelScope.launch {
+            configRepository.getMondayStart()
+                .collect { setState { copy(mondayStart = it) } }
+        }
     }
 
     suspend fun initCurrentMonthSchedules() {

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeState.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/contract/HomeState.kt
@@ -16,4 +16,5 @@ data class HomeState(
     val schedulesByTodoInfo: ImmutableMap<Int, ImmutableList<TodoScheduleUiModel>> = persistentMapOf(),
     val sortType: SortType = SortType.CREATED,
     val showWidgetNudgeDialog: Boolean = false,
+    val mondayStart: Boolean = false,
 ) : UiState

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/RepeatCycleBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/RepeatCycleBottomSheet.kt
@@ -41,6 +41,7 @@ internal fun RepeatCycleBottomSheet(
     originRepeatCycle: RepeatCycleUiModel?,
     selectedDate: LocalDate,
     openKey: Int,
+    startFromMonday: Boolean = false,
     updateRepeatCycle: (RepeatCycleUiModel) -> Unit,
     onAddRepeatCycleClick: () -> Unit,
 ) {
@@ -114,6 +115,7 @@ internal fun RepeatCycleBottomSheet(
                     calendarState = calendarState,
                     schedulesByDateMap = emptyMap(),
                     showSyncButton = false,
+                    startFromMonday = startFromMonday,
                     onSelectDate = { date ->
                         if (!date.isBefore(selectedDate)) {
                             dailyEndDate = date

--- a/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/SelectedDateBottomSheet.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/ui/bottomsheet/SelectedDateBottomSheet.kt
@@ -20,6 +20,7 @@ import java.time.LocalDate
 internal fun SelectedDateBottomSheet(
     originSelectedDate: LocalDate,
     schedulesByDateMap: Map<LocalDate, List<TodoScheduleUiModel>>,
+    startFromMonday: Boolean = false,
     updateSelectedDate: (LocalDate) -> Unit,
 ) {
     var newSelectedDate by remember(originSelectedDate) { mutableStateOf(originSelectedDate) }
@@ -31,6 +32,7 @@ internal fun SelectedDateBottomSheet(
         EbbingCalendar(
             calendarState = calendarState,
             schedulesByDateMap = schedulesByDateMap,
+            startFromMonday = startFromMonday,
             onSelectDate = { newSelectedDate = it },
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
@@ -135,6 +135,7 @@ internal fun SettingRoute(
         onPrivacyAndPolicyClick = { viewModel.onIntent(SettingIntent.OnPrivacyAndPolicyClick) },
         onTermsOfUseClick = { viewModel.onIntent(SettingIntent.OnTermsOfUseClick) },
         onNotificationToggleClick = { viewModel.onIntent(SettingIntent.OnNotificationToggleClick) },
+        onMondayStartToggleClick = { viewModel.onIntent(SettingIntent.OnMondayStartToggleClick) },
         onInAppReviewClick = { viewModel.onIntent(SettingIntent.OnInAppReviewClick) },
         onUpdateClick = { isImmediateUpdate ->
             viewModel.onIntent(SettingIntent.OnUpdateClick(isImmediateUpdate))
@@ -157,6 +158,7 @@ private fun SettingScreen(
     onPrivacyAndPolicyClick: () -> Unit,
     onTermsOfUseClick: () -> Unit,
     onNotificationToggleClick: () -> Unit,
+    onMondayStartToggleClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
 ) {
@@ -187,6 +189,7 @@ private fun SettingScreen(
             onPrivacyAndPolicyClick = onPrivacyAndPolicyClick,
             onTermsOfUseClick = onTermsOfUseClick,
             onNotificationToggleClick = onNotificationToggleClick,
+            onMondayStartToggleClick = onMondayStartToggleClick,
             onInAppReviewClick = onInAppReviewClick,
             onUpdateClick = onUpdateClick,
         )
@@ -205,6 +208,7 @@ private fun SettingScreen(
             onPrivacyAndPolicyClick = onPrivacyAndPolicyClick,
             onTermsOfUseClick = onTermsOfUseClick,
             onNotificationToggleClick = onNotificationToggleClick,
+            onMondayStartToggleClick = onMondayStartToggleClick,
             onInAppReviewClick = onInAppReviewClick,
             onUpdateClick = onUpdateClick,
         )
@@ -226,6 +230,7 @@ private fun PhoneSettingScreen(
     onPrivacyAndPolicyClick: () -> Unit,
     onTermsOfUseClick: () -> Unit,
     onNotificationToggleClick: () -> Unit,
+    onMondayStartToggleClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
 ) {
@@ -259,6 +264,11 @@ private fun PhoneSettingScreen(
             TagRepeatCycleBody(
                 onTagManageClick = onTagManageClick,
                 onRepeatCycleManageClick = onRepeatCycleManageClick,
+            )
+
+            CalendarStartDayBody(
+                mondayStart = state.mondayStart,
+                onMondayStartToggleClick = onMondayStartToggleClick,
             )
 
             DataBody(
@@ -308,6 +318,7 @@ private fun TabletSettingScreen(
     onPrivacyAndPolicyClick: () -> Unit,
     onTermsOfUseClick: () -> Unit,
     onNotificationToggleClick: () -> Unit,
+    onMondayStartToggleClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
 ) {
@@ -340,6 +351,11 @@ private fun TabletSettingScreen(
                 TagRepeatCycleBody(
                     onTagManageClick = onTagManageClick,
                     onRepeatCycleManageClick = onRepeatCycleManageClick,
+                )
+
+                CalendarStartDayBody(
+                    mondayStart = state.mondayStart,
+                    onMondayStartToggleClick = onMondayStartToggleClick,
                 )
 
                 DataBody(
@@ -509,6 +525,51 @@ private fun NotificationBody(
         modifier = Modifier.padding(vertical = 16.dp),
         thickness = 1.dp,
         color = EbbingTheme.colors.light2
+    )
+}
+
+@Composable
+private fun CalendarStartDayBody(
+    mondayStart: Boolean,
+    onMondayStartToggleClick: () -> Unit,
+) {
+    Text(
+        text = "달력",
+        style = EbbingTheme.typography.bodySM,
+        color = EbbingTheme.colors.dark2,
+        modifier = Modifier.padding(bottom = 8.dp),
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 17.dp),
+    ) {
+        Text(
+            text = "달력 시작 요일",
+            style = EbbingTheme.typography.headingSSB,
+            color = EbbingTheme.colors.dark1,
+            modifier = Modifier.weight(1f),
+        )
+
+        Text(
+            text = if (mondayStart) "월" else "일",
+            style = EbbingTheme.typography.headingSM,
+            color = if (mondayStart) EbbingTheme.colors.primaryDefault else EbbingTheme.colors.dark2,
+            modifier = Modifier.padding(end = 12.dp),
+        )
+
+        EbbingToggle(
+            checked = mondayStart,
+            onCheckedChange = { onMondayStartToggleClick() },
+        )
+    }
+
+    HorizontalDivider(
+        color = EbbingTheme.colors.light2,
+        thickness = 1.dp,
+        modifier = Modifier.padding(vertical = 16.dp),
     )
 }
 
@@ -968,6 +1029,7 @@ private fun PreviewSettingScreen() {
             onPrivacyAndPolicyClick = {},
             onTermsOfUseClick = {},
             onNotificationToggleClick = {},
+            onMondayStartToggleClick = {},
             onInAppReviewClick = {},
             onUpdateClick = {},
         )

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
@@ -74,6 +74,11 @@ class SettingViewModel @Inject constructor(
                 }.onSuccess { setState { copy(hardUpdateInfo = it) } }
             }
 
+            launch {
+                configRepository.getMondayStart()
+                    .collect { setState { copy(mondayStart = it) } }
+            }
+
             configRepository.getNotificationEnabled()
                 .collect { setState { copy(notificationEnabled = it) } }
         }
@@ -142,6 +147,9 @@ class SettingViewModel @Inject constructor(
             is SettingIntent.OnUpdateClick -> _sideEffect.send(
                 SettingSideEffect.RequestInAppUpdate(intent.isImmediateUpdate)
             )
+
+            SettingIntent.OnMondayStartToggleClick ->
+                configRepository.setMondayStart(!currentState.mondayStart)
         }
     }
 

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
@@ -22,4 +22,5 @@ sealed interface SettingIntent : UiIntent {
     data object OnNotificationToggleClick : SettingIntent
     data object OnInAppReviewClick : SettingIntent
     data class OnUpdateClick(val isImmediateUpdate: Boolean) : SettingIntent
+    data object OnMondayStartToggleClick : SettingIntent
 }

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingState.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingState.kt
@@ -12,6 +12,7 @@ data class SettingState(
     val alarmMinute: String = "",
     val alarmMessage: String = DEFAULT_ALARM_MESSAGE,
     val alarmMessageBottomSheet: AlarmMessageBottomSheetState = AlarmMessageBottomSheetState(),
+    val mondayStart: Boolean = false,
 ) : UiState
 
 data class AlarmMessageBottomSheetState(


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- 달력 월/일 시작 요일 토글 기능 추가

## 2. 🖼️ 스크린샷(선택)

<img width="952" height="374" alt="image" src="https://github.com/user-attachments/assets/f70746d0-0fbc-420a-841a-99294d84d01c" />

https://github.com/user-attachments/assets/f6031d1b-48d1-4562-b50f-06b396c9ddc7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 메뉴에서 달력의 주 시작 요일을 월요일 또는 일요일로 선택할 수 있습니다.
  * 선택한 설정이 메인 달력, 할일 추가/편집 화면의 날짜 선택 달력, 위젯 달력에 모두 반영됩니다.
  * 사용자 선호도는 자동으로 저장되어 앱 재실행 후에도 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->