### PR TITLE
[Fix] 앱 리뷰 버튼 클릭 시 Play Store로 직접 이동하도록 변경

### DIFF
--- a/core/in-app-review/src/main/java/com/tgyuu/inappreview/InAppReviewManager.kt
+++ b/core/in-app-review/src/main/java/com/tgyuu/inappreview/InAppReviewManager.kt
@@ -16,7 +16,7 @@ class InAppReviewManager @Inject constructor(
 ) {
     private val reviewManager: ReviewManager = ReviewManagerFactory.create(context)
 
-    suspend fun requestAndLaunchReview(activity: Activity) {
+    suspend fun requestInAppReview(activity: Activity) {
         try {
             val reviewInfo = reviewManager.requestReviewFlow().await()
             reviewManager.launchReviewFlow(activity, reviewInfo)
@@ -27,9 +27,5 @@ class InAppReviewManager @Inject constructor(
 
     fun openPlayStoreForReview() {
         context.openPlayStore()
-    }
-
-    companion object {
-        private const val TAG = "InAppReviewManager"
     }
 }

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
@@ -81,12 +81,7 @@ internal fun SettingRoute(
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 SettingSideEffect.RequestInAppReview -> {
-                    if (activity != null) {
-                        viewModel.inAppReviewManager.requestAndLaunchReview(activity)
-                    } else {
-                        viewModel.inAppReviewManager.
-                        openPlayStoreForReview()
-                    }
+                    viewModel.inAppReviewManager.openPlayStoreForReview()
                 }
                 is SettingSideEffect.RequestInAppUpdate -> {
                     activity?.let {


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- 인앱 리뷰 API는 쿼터 제한으로 버튼 클릭 시 다이얼로그가 안 뜰 수 있어서
- Play Store 직접 이동으로 변경하고, 인앱 리뷰 로직은 자동 트리거용으로 보존


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 인앱 리뷰 요청 프로세스의 내부 구조를 간소화했습니다.

* **버그 수정**
  * 리뷰 요청 흐름을 개선하여 플레이 스토어 연결이 더욱 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->