### PR TITLE
[Feature] 위젯 폰트 적용

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -1,6 +1,7 @@
 package com.tgyuu.ebbingplanner.widget.calendar
 
 import android.content.Context
+import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -63,6 +64,7 @@ import com.tgyuu.ebbingplanner.widget.designsystem.foundation.THEME
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.WIDGET_MONDAY_START
 import com.tgyuu.ebbingplanner.widget.todaytodo.TodoItemRow
 import com.tgyuu.ebbingplanner.widget.util.AddTodoFromWidgetAction
+import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
 import com.tgyuu.ebbingplanner.widget.util.SelectDateAction
 import com.tgyuu.ebbingplanner.widget.util.SelectDateAction.Companion.SELECTED_DATE
@@ -72,6 +74,11 @@ import java.time.LocalDate
 
 class CalendarWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val headerBitmap = PretendardBitmapRenderer.loadBitmap(context, "calendar_header.png")
+        val dowBitmaps = (0 until 7).map { i ->
+            PretendardBitmapRenderer.loadBitmap(context, "calendar_dow_$i.png")
+        }
+
         provideContent {
             val prefs = currentState<Preferences>()
 
@@ -104,6 +111,8 @@ class CalendarWidget : GlanceAppWidget() {
                     selectedDate = selectedDate,
                     calendarDates = calendarDates,
                     mondayStart = mondayStart,
+                    headerBitmap = headerBitmap,
+                    dowBitmaps = dowBitmaps,
                 )
             }
         }
@@ -117,6 +126,8 @@ private fun CalendarWidgetContent(
     calendarDates: List<CalendarDate>,
     selectedDate: LocalDate,
     mondayStart: Boolean,
+    headerBitmap: Bitmap?,
+    dowBitmaps: List<Bitmap?>,
 ) {
     val selectedDateTodoLists = schedulesByDateMap[selectedDate] ?: emptyList()
     val todoListsDoneSize = selectedDateTodoLists.filter { it.isDone }.size
@@ -136,7 +147,12 @@ private fun CalendarWidgetContent(
             )
             .padding(vertical = 16.dp, horizontal = 20.dp)
     ) {
-        CalendarWidgetHeader(mondayStart = mondayStart, selectedDate = selectedDate)
+        CalendarWidgetHeader(
+            mondayStart = mondayStart,
+            selectedDate = selectedDate,
+            headerBitmap = headerBitmap,
+            dowBitmaps = dowBitmaps,
+        )
 
         CalendarWidgetBody(
             calendarDates = calendarDates,
@@ -154,21 +170,33 @@ private fun CalendarWidgetContent(
 }
 
 @Composable
-private fun CalendarWidgetHeader(mondayStart: Boolean, selectedDate: LocalDate) {
+private fun CalendarWidgetHeader(
+    mondayStart: Boolean,
+    selectedDate: LocalDate,
+    headerBitmap: Bitmap?,
+    dowBitmaps: List<Bitmap?>,
+) {
     val today = LocalDate.now()
     Column(modifier = GlanceModifier.fillMaxWidth()) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = GlanceModifier.fillMaxWidth()
-                .height(24.dp),
+            modifier = GlanceModifier.fillMaxWidth(),
         ) {
-            Text(
-                text = "${today.year}년 ${today.monthValue}월",
-                style = EbbingWidgetTypography.heading16B.copy(
-                    color = LocalEbbingWidgetColors.current.textOnBackground,
-                ),
-                modifier = GlanceModifier.defaultWeight()
-            )
+            if (headerBitmap != null) {
+                Image(
+                    provider = ImageProvider(headerBitmap),
+                    contentDescription = null,
+                )
+                Spacer(modifier = GlanceModifier.defaultWeight())
+            } else {
+                Text(
+                    text = "${today.year}년 ${today.monthValue}월",
+                    style = EbbingWidgetTypography.heading16B.copy(
+                        color = LocalEbbingWidgetColors.current.textOnBackground,
+                    ),
+                    modifier = GlanceModifier.defaultWeight(),
+                )
+            }
 
             Image(
                 provider = ImageProvider(R.drawable.ic_widget_plus),
@@ -203,15 +231,28 @@ private fun CalendarWidgetHeader(mondayStart: Boolean, selectedDate: LocalDate) 
         Spacer(modifier = GlanceModifier.size(12.dp))
 
         Row(modifier = GlanceModifier.fillMaxWidth()) {
-            getEbbingDayOfWeek(mondayStart).forEach {
-                Text(
-                    text = it.toKorean(),
-                    style = EbbingWidgetTypography.body14M.copy(
-                        textAlign = TextAlign.Center,
-                        color = LocalEbbingWidgetColors.current.textSub,
-                    ),
-                    modifier = GlanceModifier.defaultWeight(),
-                )
+            getEbbingDayOfWeek(mondayStart).forEachIndexed { index, dow ->
+                val dowBitmap = dowBitmaps.getOrNull(index)
+                if (dowBitmap != null) {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = GlanceModifier.defaultWeight(),
+                    ) {
+                        Image(
+                            provider = ImageProvider(dowBitmap),
+                            contentDescription = null,
+                        )
+                    }
+                } else {
+                    Text(
+                        text = dow.toKorean(),
+                        style = EbbingWidgetTypography.body14M.copy(
+                            textAlign = TextAlign.Center,
+                            color = LocalEbbingWidgetColors.current.textSub,
+                        ),
+                        modifier = GlanceModifier.defaultWeight(),
+                    )
+                }
             }
         }
 
@@ -352,7 +393,7 @@ private fun ColumnScope.SelectedDateTodoList(
                 ),
             )
             Text(
-                text = " /${todoLists.size}",
+                text = "/${todoLists.size}",
                 style = EbbingWidgetTypography.heading16B.copy(
                     color = LocalEbbingWidgetColors.current.textDisabled,
                 ),

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -185,7 +185,7 @@ private fun CalendarWidgetHeader(
             if (headerBitmap != null) {
                 Image(
                     provider = ImageProvider(headerBitmap),
-                    contentDescription = null,
+                    contentDescription = "${today.year}년 ${today.monthValue}월",
                 )
                 Spacer(modifier = GlanceModifier.defaultWeight())
             } else {
@@ -240,7 +240,7 @@ private fun CalendarWidgetHeader(
                     ) {
                         Image(
                             provider = ImageProvider(dowBitmap),
-                            contentDescription = null,
+                            contentDescription = dow.toKorean(),
                         )
                     }
                 } else {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -40,9 +40,11 @@ import com.tgyuu.ebbingplanner.widget.util.GsonProvider
 import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -126,7 +128,9 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
         )
         val byDate = buildByDateMap(allSchedules, sortType)
 
-        generatePretendardBitmaps(context, theme, textAlpha, mondayStart, now)
+        withContext(Dispatchers.IO) {
+            generatePretendardBitmaps(context, theme, textAlpha, mondayStart, now)
+        }
 
         val glanceId = GlanceAppWidgetManager(context)
             .getGlanceIds(CalendarWidget::class.java)

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -3,12 +3,26 @@ package com.tgyuu.ebbingplanner.widget.calendar
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
+import androidx.compose.ui.graphics.toArgb
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.tgyuu.designsystem.component.calendar.getEbbingDayOfWeek
+import com.tgyuu.designsystem.component.calendar.toKorean
+import com.tgyuu.designsystem.foundation.forestDarkColorScheme
+import com.tgyuu.designsystem.foundation.forestLightColorScheme
+import com.tgyuu.designsystem.foundation.lilacDarkColorScheme
+import com.tgyuu.designsystem.foundation.lilacLightColorScheme
+import com.tgyuu.designsystem.foundation.marineDarkColorScheme
+import com.tgyuu.designsystem.foundation.marineLightColorScheme
+import com.tgyuu.designsystem.foundation.normalDarkColorScheme
+import com.tgyuu.designsystem.foundation.normalLightColorScheme
+import com.tgyuu.designsystem.foundation.sunsetDarkColorScheme
+import com.tgyuu.designsystem.foundation.sunsetLightColorScheme
 import com.tgyuu.domain.model.SortType
 import com.tgyuu.domain.model.Theme
 import com.tgyuu.domain.model.TodoSchedule
@@ -23,6 +37,7 @@ import com.tgyuu.ebbingplanner.widget.util.CheckTodoAction.Companion.TODO_ID
 import com.tgyuu.analytics.AnalyticsEvent
 import com.tgyuu.analytics.AnalyticsHelper
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
+import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.MainScope
@@ -111,6 +126,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
         )
         val byDate = buildByDateMap(allSchedules, sortType)
 
+        generatePretendardBitmaps(context, theme, textAlpha, mondayStart, now)
+
         val glanceId = GlanceAppWidgetManager(context)
             .getGlanceIds(CalendarWidget::class.java)
             .firstOrNull()
@@ -129,6 +146,44 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
             }
 
             glanceAppWidget.update(context, it)
+        }
+    }
+
+    private fun generatePretendardBitmaps(
+        context: Context,
+        theme: Theme,
+        textAlpha: Float,
+        mondayStart: Boolean,
+        now: LocalDate,
+    ) {
+        val isDark = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+
+        val colorScheme = when (theme) {
+            Theme.NORMAL -> if (isDark) normalDarkColorScheme else normalLightColorScheme
+            Theme.FOREST -> if (isDark) forestDarkColorScheme else forestLightColorScheme
+            Theme.SUNSET -> if (isDark) sunsetDarkColorScheme else sunsetLightColorScheme
+            Theme.MARINE -> if (isDark) marineDarkColorScheme else marineLightColorScheme
+            Theme.LILAC -> if (isDark) lilacDarkColorScheme else lilacLightColorScheme
+        }
+
+        val textOnBackground = colorScheme.textOnBackground.copy(alpha = textAlpha).toArgb()
+        val textSub = colorScheme.textSub.copy(alpha = textAlpha).toArgb()
+
+        // 년/월 헤더
+        PretendardBitmapRenderer.renderAndSave(
+            context, "${now.year}년 ${now.monthValue}월",
+            PretendardBitmapRenderer.Weight.BOLD, 16f, textOnBackground,
+            filename = "calendar_header.png",
+        )
+
+        // 요일 라벨 (0~6)
+        getEbbingDayOfWeek(mondayStart).forEachIndexed { index, dow ->
+            PretendardBitmapRenderer.renderAndSave(
+                context, dow.toKorean(),
+                PretendardBitmapRenderer.Weight.MEDIUM, 14f, textSub,
+                filename = "calendar_dow_$index.png",
+            )
         }
     }
 

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -141,13 +141,11 @@ private fun TodayTodoWidgetContent(
                 imageProvider = ImageProvider(backgroundImage),
                 colorFilter = ColorFilter.tint(LocalEbbingWidgetColors.current.background),
             )
-            .padding(4.dp)
+            .padding(20.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = GlanceModifier.fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .padding(top = 6.dp),
+            modifier = GlanceModifier.fillMaxWidth(),
         ) {
             val todoListsDoneSize = todoLists.filter { it.isDone }.size
 
@@ -156,7 +154,7 @@ private fun TodayTodoWidgetContent(
                 modifier = GlanceModifier.defaultWeight(),
             ) {
                 if (headerBitmap != null) {
-                    Image(provider = ImageProvider(headerBitmap), contentDescription = null)
+                    Image(provider = ImageProvider(headerBitmap), contentDescription = "오늘 할 일")
                 } else {
                     Text(
                         text = "오늘 할 일   ",
@@ -166,7 +164,10 @@ private fun TodayTodoWidgetContent(
                     )
                 }
                 if (doneBitmap != null) {
-                    Image(provider = ImageProvider(doneBitmap), contentDescription = null)
+                    Image(
+                        provider = ImageProvider(doneBitmap),
+                        contentDescription = "완료 ${todoListsDoneSize}개",
+                    )
                 } else {
                     Text(
                         text = todoListsDoneSize.toString(),
@@ -177,7 +178,10 @@ private fun TodayTodoWidgetContent(
                     )
                 }
                 if (totalBitmap != null) {
-                    Image(provider = ImageProvider(totalBitmap), contentDescription = null)
+                    Image(
+                        provider = ImageProvider(totalBitmap),
+                        contentDescription = "전체 ${todoLists.size}개",
+                    )
                 } else {
                     Text(
                         text = "/${todoLists.size}",
@@ -205,8 +209,8 @@ private fun TodayTodoWidgetContent(
             if (emptyBitmap != null) {
                 Image(
                     provider = ImageProvider(emptyBitmap),
-                    contentDescription = null,
-                    modifier = GlanceModifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    contentDescription = "오늘은 일정이 없어요",
+                    modifier = GlanceModifier.padding(vertical = 12.dp),
                 )
             } else {
                 Text(
@@ -216,7 +220,7 @@ private fun TodayTodoWidgetContent(
                         color = LocalEbbingWidgetColors.current.textSub,
                     ),
                     modifier = GlanceModifier.fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                        .padding(vertical = 12.dp),
                 )
             }
         } else {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -2,6 +2,7 @@ package com.tgyuu.ebbingplanner.widget.todaytodo
 
 import android.content.ComponentName
 import android.content.Context
+import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -53,6 +54,7 @@ import com.tgyuu.ebbingplanner.widget.designsystem.foundation.EbbingWidgetTypogr
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.LocalEbbingWidgetColors
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.TEXT_ALPHA
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.THEME
+import com.tgyuu.ebbingplanner.widget.todaytodo.TodayTodoWidgetReceiver.Companion.MAX_VISIBLE_TODOS
 import com.tgyuu.ebbingplanner.widget.todaytodo.TodayTodoWidgetReceiver.Companion.TODO_LISTS
 import com.tgyuu.ebbingplanner.widget.util.ACTION_OPEN_ADD_TODO
 import com.tgyuu.ebbingplanner.widget.util.AddTodoFromWidgetAction
@@ -60,12 +62,21 @@ import com.tgyuu.ebbingplanner.widget.util.BaseWidgetPreview
 import com.tgyuu.ebbingplanner.widget.util.CheckTodoAction
 import com.tgyuu.ebbingplanner.widget.util.EbbingWidgetPreview
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
+import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.todoIdKey
 import com.tgyuu.ebbingplanner.widget.util.widgetSourceKey
 import java.time.LocalDate
 
 class TodayTodoWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val headerBitmap = PretendardBitmapRenderer.loadBitmap(context, "todo_header.png")
+        val doneBitmap = PretendardBitmapRenderer.loadBitmap(context, "todo_done_count.png")
+        val totalBitmap = PretendardBitmapRenderer.loadBitmap(context, "todo_total.png")
+        val emptyBitmap = PretendardBitmapRenderer.loadBitmap(context, "todo_empty.png")
+        val titleBitmaps = (0 until MAX_VISIBLE_TODOS).map { i ->
+            PretendardBitmapRenderer.loadBitmap(context, "todo_title_$i.png")
+        }
+
         provideContent {
             val prefs = currentState<Preferences>()
 
@@ -86,6 +97,11 @@ class TodayTodoWidget : GlanceAppWidget() {
                 TodayTodoWidgetContent(
                     alpha = backgroundAlpha,
                     todoLists = todoLists,
+                    headerBitmap = headerBitmap,
+                    doneBitmap = doneBitmap,
+                    totalBitmap = totalBitmap,
+                    emptyBitmap = emptyBitmap,
+                    titleBitmaps = titleBitmaps,
                 )
             }
         }
@@ -96,6 +112,11 @@ class TodayTodoWidget : GlanceAppWidget() {
 private fun TodayTodoWidgetContent(
     alpha: Float,
     todoLists: List<TodoSchedule>,
+    headerBitmap: Bitmap?,
+    doneBitmap: Bitmap?,
+    totalBitmap: Bitmap?,
+    emptyBitmap: Bitmap?,
+    titleBitmaps: List<Bitmap?>,
 ) {
     val backgroundImage = when (alpha) {
         0.25f -> R.drawable.shape_widget_background_25
@@ -128,34 +149,43 @@ private fun TodayTodoWidgetContent(
                 .padding(horizontal = 20.dp)
                 .padding(top = 6.dp),
         ) {
+            val todoListsDoneSize = todoLists.filter { it.isDone }.size
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = GlanceModifier.defaultWeight()
+                modifier = GlanceModifier.defaultWeight(),
             ) {
-                val todoListsDoneSize = todoLists.filter { it.isDone }.size
-
-                Text(
-                    text = "오늘 할 일   ",
-                    style = EbbingWidgetTypography.heading18B.copy(
-                        textAlign = TextAlign.Start,
-                        color = LocalEbbingWidgetColors.current.textOnBackground,
-                    ),
-                )
-                Text(
-                    text = todoListsDoneSize.toString(),
-                    style = EbbingWidgetTypography.heading18B.copy(
-                        textAlign = TextAlign.Start,
-                        color = if (todoListsDoneSize > 0) LocalEbbingWidgetColors.current.textPrimary
-                        else LocalEbbingWidgetColors.current.textDisabled,
-                    ),
-                )
-                Text(
-                    text = " /${todoLists.size}",
-                    style = EbbingWidgetTypography.heading18B.copy(
-                        textAlign = TextAlign.Start,
-                        color = LocalEbbingWidgetColors.current.textDisabled,
-                    ),
-                )
+                if (headerBitmap != null) {
+                    Image(provider = ImageProvider(headerBitmap), contentDescription = null)
+                } else {
+                    Text(
+                        text = "오늘 할 일   ",
+                        style = EbbingWidgetTypography.heading18B.copy(
+                            color = LocalEbbingWidgetColors.current.textOnBackground,
+                        ),
+                    )
+                }
+                if (doneBitmap != null) {
+                    Image(provider = ImageProvider(doneBitmap), contentDescription = null)
+                } else {
+                    Text(
+                        text = todoListsDoneSize.toString(),
+                        style = EbbingWidgetTypography.heading18B.copy(
+                            color = if (todoListsDoneSize > 0) LocalEbbingWidgetColors.current.textPrimary
+                            else LocalEbbingWidgetColors.current.textDisabled,
+                        ),
+                    )
+                }
+                if (totalBitmap != null) {
+                    Image(provider = ImageProvider(totalBitmap), contentDescription = null)
+                } else {
+                    Text(
+                        text = "/${todoLists.size}",
+                        style = EbbingWidgetTypography.heading18B.copy(
+                            color = LocalEbbingWidgetColors.current.textDisabled,
+                        ),
+                    )
+                }
             }
 
             Image(
@@ -172,23 +202,32 @@ private fun TodayTodoWidgetContent(
         }
 
         if (todoLists.isEmpty()) {
-            Text(
-                text = "오늘은 일정이 없어요",
-                style = EbbingWidgetTypography.heading16SB.copy(
-                    textAlign = TextAlign.Start,
-                    color = LocalEbbingWidgetColors.current.textSub,
-                ),
-                modifier = GlanceModifier.fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 12.dp),
-            )
+            if (emptyBitmap != null) {
+                Image(
+                    provider = ImageProvider(emptyBitmap),
+                    contentDescription = null,
+                    modifier = GlanceModifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                )
+            } else {
+                Text(
+                    text = "오늘은 일정이 없어요",
+                    style = EbbingWidgetTypography.heading16SB.copy(
+                        textAlign = TextAlign.Start,
+                        color = LocalEbbingWidgetColors.current.textSub,
+                    ),
+                    modifier = GlanceModifier.fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                )
+            }
         } else {
             LazyColumn(
                 modifier = GlanceModifier.fillMaxSize()
                     .padding(horizontal = 20.dp, vertical = 12.dp)
             ) {
-                items(items = todoLists) { item ->
+                items(items = todoLists.mapIndexed { i, it -> i to it }) { (index, item) ->
                     TodoItemRow(
                         todo = item,
+                        titleBitmap = titleBitmaps.getOrNull(index),
                         modifier = GlanceModifier.fillMaxWidth()
                             .padding(vertical = 6.dp),
                     )
@@ -201,6 +240,7 @@ private fun TodayTodoWidgetContent(
 @Composable
 internal fun TodoItemRow(
     todo: TodoSchedule,
+    titleBitmap: Bitmap? = null,
     modifier: GlanceModifier = GlanceModifier,
 ) {
     Row(
@@ -215,16 +255,24 @@ internal fun TodoItemRow(
                 .background(ColorProvider(Color(todo.color), Color(todo.color)))
         )
 
-        Text(
-            text = todo.title,
-            style = (if (todo.isDone) EbbingWidgetTypography.body14M else EbbingWidgetTypography.heading14SB).copy(
-                color = if (todo.isDone) LocalEbbingWidgetColors.current.textDisabled else LocalEbbingWidgetColors.current.textOnBackground,
-                textDecoration = if (todo.isDone) TextDecoration.LineThrough else null,
-            ),
-            maxLines = 2,
-            modifier = GlanceModifier.padding(horizontal = 12.dp)
-                .defaultWeight(),
-        )
+        if (titleBitmap != null) {
+            Image(
+                provider = ImageProvider(titleBitmap),
+                contentDescription = todo.title,
+                modifier = GlanceModifier.padding(horizontal = 12.dp).defaultWeight(),
+            )
+        } else {
+            Text(
+                text = todo.title,
+                style = (if (todo.isDone) EbbingWidgetTypography.body14M else EbbingWidgetTypography.heading14SB).copy(
+                    color = if (todo.isDone) LocalEbbingWidgetColors.current.textDisabled else LocalEbbingWidgetColors.current.textOnBackground,
+                    textDecoration = if (todo.isDone) TextDecoration.LineThrough else null,
+                ),
+                maxLines = 2,
+                modifier = GlanceModifier.padding(horizontal = 12.dp)
+                    .defaultWeight(),
+            )
+        }
 
         EbbingWidgetCheck(
             checked = todo.isDone,
@@ -242,7 +290,12 @@ private fun HomeWidgetPreview() {
     BaseWidgetPreview {
         TodayTodoWidgetContent(
             alpha = 1f,
-            todoLists = emptyList()
+            todoLists = emptyList(),
+            headerBitmap = null,
+            doneBitmap = null,
+            totalBitmap = null,
+            emptyBitmap = null,
+            titleBitmaps = emptyList(),
         )
     }
 }
@@ -253,6 +306,11 @@ private fun HomeWidgetPreview2() {
     BaseWidgetPreview {
         TodayTodoWidgetContent(
             alpha = 1f,
+            headerBitmap = null,
+            doneBitmap = null,
+            totalBitmap = null,
+            emptyBitmap = null,
+            titleBitmaps = emptyList(),
             todoLists = listOf(
                 TodoSchedule(
                     id = 1,

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -1,6 +1,7 @@
 package com.tgyuu.ebbingplanner.widget.todaytodo
 
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -38,9 +39,11 @@ import com.tgyuu.ebbingplanner.widget.util.KEY_WIDGET_SOURCE
 import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -126,7 +129,9 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
             .loadSchedulesByDate(LocalDate.now())
             .sortedWith(compareBy({ it.isDone }, { it.title }))
 
-        generatePretendardBitmaps(context, theme, textAlpha, todoLists)
+        withContext(Dispatchers.IO) {
+            generatePretendardBitmaps(context, theme, textAlpha, todoLists)
+        }
 
         val glanceId = GlanceAppWidgetManager(context)
             .getGlanceIds(TodayTodoWidget::class.java)
@@ -172,9 +177,18 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
 
         val doneSize = todoLists.count { it.isDone }
         val density = context.resources.displayMetrics.density
-        // 화면 너비에서 외부 패딩(40dp) + 색상 바·패딩(15dp) + 체크 아이콘(20dp) + 이미지 내부 패딩(24dp) 제외
-        val titleMaxWidthPx = (context.resources.displayMetrics.widthPixels - (99 * density).toInt())
-            .coerceAtLeast(100)
+        // 실제 위젯 인스턴스 중 가장 작은 너비 기준으로 비트맵 폭 계산 (없으면 XML minWidth 180dp)
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val widgetIds = appWidgetManager.getAppWidgetIds(
+            ComponentName(context, TodayTodoWidgetReceiver::class.java)
+        )
+        val minWidgetWidthDp = widgetIds.toList().mapNotNull { id ->
+            appWidgetManager.getAppWidgetOptions(id)
+                .getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, -1)
+                .takeIf { it > 0 }
+        }.minOrNull() ?: 180
+        // 외부 패딩(40dp) + 색상 바·패딩(15dp) + 체크 아이콘(20dp) + 이미지 내부 패딩(24dp) 제외
+        val titleMaxWidthPx = ((minWidgetWidthDp - 99) * density).toInt().coerceAtLeast(50)
 
         PretendardBitmapRenderer.renderAndSave(
             context, "오늘 할 일   ",
@@ -190,7 +204,7 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
         )
 
         PretendardBitmapRenderer.renderAndSave(
-            context, " /${todoLists.size}",
+            context, "/${todoLists.size}",
             PretendardBitmapRenderer.Weight.BOLD, 18f, textDisabled,
             filename = "todo_total.png",
         )

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -3,13 +3,26 @@ package com.tgyuu.ebbingplanner.widget.todaytodo
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
+import androidx.compose.ui.graphics.toArgb
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.tgyuu.designsystem.foundation.forestDarkColorScheme
+import com.tgyuu.designsystem.foundation.forestLightColorScheme
+import com.tgyuu.designsystem.foundation.lilacDarkColorScheme
+import com.tgyuu.designsystem.foundation.lilacLightColorScheme
+import com.tgyuu.designsystem.foundation.marineDarkColorScheme
+import com.tgyuu.designsystem.foundation.marineLightColorScheme
+import com.tgyuu.designsystem.foundation.normalDarkColorScheme
+import com.tgyuu.designsystem.foundation.normalLightColorScheme
+import com.tgyuu.designsystem.foundation.sunsetDarkColorScheme
+import com.tgyuu.designsystem.foundation.sunsetLightColorScheme
 import com.tgyuu.domain.model.Theme
+import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.ebbingplanner.widget.designsystem.foundation.BACKGROUND_ALPHA
@@ -22,6 +35,7 @@ import com.tgyuu.analytics.AnalyticsHelper
 import com.tgyuu.ebbingplanner.widget.util.ADD_TODO_ACTION
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
 import com.tgyuu.ebbingplanner.widget.util.KEY_WIDGET_SOURCE
+import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.MainScope
@@ -112,6 +126,8 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
             .loadSchedulesByDate(LocalDate.now())
             .sortedWith(compareBy({ it.isDone }, { it.title }))
 
+        generatePretendardBitmaps(context, theme, textAlpha, todoLists)
+
         val glanceId = GlanceAppWidgetManager(context)
             .getGlanceIds(TodayTodoWidget::class.java)
             .firstOrNull()
@@ -132,7 +148,76 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
         }
     }
 
+    private fun generatePretendardBitmaps(
+        context: Context,
+        theme: Theme,
+        textAlpha: Float,
+        todoLists: List<TodoSchedule>,
+    ) {
+        val isDark = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+
+        val colorScheme = when (theme) {
+            Theme.NORMAL -> if (isDark) normalDarkColorScheme else normalLightColorScheme
+            Theme.FOREST -> if (isDark) forestDarkColorScheme else forestLightColorScheme
+            Theme.SUNSET -> if (isDark) sunsetDarkColorScheme else sunsetLightColorScheme
+            Theme.MARINE -> if (isDark) marineDarkColorScheme else marineLightColorScheme
+            Theme.LILAC -> if (isDark) lilacDarkColorScheme else lilacLightColorScheme
+        }
+
+        val textOnBackground = colorScheme.textOnBackground.copy(alpha = textAlpha).toArgb()
+        val textPrimary = colorScheme.textPrimary.copy(alpha = textAlpha).toArgb()
+        val textDisabled = colorScheme.textDisabled.copy(alpha = textAlpha).toArgb()
+        val textSub = colorScheme.textSub.copy(alpha = textAlpha).toArgb()
+
+        val doneSize = todoLists.count { it.isDone }
+        val density = context.resources.displayMetrics.density
+        // 화면 너비에서 외부 패딩(40dp) + 색상 바·패딩(15dp) + 체크 아이콘(20dp) + 이미지 내부 패딩(24dp) 제외
+        val titleMaxWidthPx = (context.resources.displayMetrics.widthPixels - (99 * density).toInt())
+            .coerceAtLeast(100)
+
+        PretendardBitmapRenderer.renderAndSave(
+            context, "오늘 할 일   ",
+            PretendardBitmapRenderer.Weight.BOLD, 18f, textOnBackground,
+            filename = "todo_header.png",
+        )
+
+        val doneColor = if (doneSize > 0) textPrimary else textDisabled
+        PretendardBitmapRenderer.renderAndSave(
+            context, doneSize.toString(),
+            PretendardBitmapRenderer.Weight.BOLD, 18f, doneColor,
+            filename = "todo_done_count.png",
+        )
+
+        PretendardBitmapRenderer.renderAndSave(
+            context, " /${todoLists.size}",
+            PretendardBitmapRenderer.Weight.BOLD, 18f, textDisabled,
+            filename = "todo_total.png",
+        )
+
+        PretendardBitmapRenderer.renderAndSave(
+            context, "오늘은 일정이 없어요",
+            PretendardBitmapRenderer.Weight.SEMI_BOLD, 16f, textSub,
+            filename = "todo_empty.png",
+        )
+
+        todoLists.take(MAX_VISIBLE_TODOS).forEachIndexed { index, todo ->
+            val titleColor = if (todo.isDone) textDisabled else textOnBackground
+            val weight = if (todo.isDone) PretendardBitmapRenderer.Weight.MEDIUM
+                         else PretendardBitmapRenderer.Weight.SEMI_BOLD
+            PretendardBitmapRenderer.renderAndSave(
+                context, todo.title,
+                weight, 14f, titleColor,
+                filename = "todo_title_$index.png",
+                maxWidthPx = titleMaxWidthPx,
+                maxLines = 2,
+                strikethrough = todo.isDone,
+            )
+        }
+    }
+
     companion object {
         val TODO_LISTS = stringPreferencesKey("todoLists")
+        const val MAX_VISIBLE_TODOS = 20
     }
 }

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/PretendardBitmapRenderer.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/PretendardBitmapRenderer.kt
@@ -83,12 +83,14 @@ object PretendardBitmapRenderer {
         return bitmap
     }
 
-    /** 렌더링 결과를 내부 저장소 파일로 저장한다. */
+    /** 렌더링 결과를 내부 저장소 파일로 원자적으로 저장한다. */
     fun saveBitmap(context: Context, bitmap: Bitmap, filename: String): File {
         val dir = File(context.filesDir, "widget_bitmaps").also { it.mkdirs() }
-        val file = File(dir, filename)
-        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
-        return file
+        val target = File(dir, filename)
+        val temp = File(dir, "$filename.tmp")
+        temp.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        temp.renameTo(target)
+        return target
     }
 
     /** 저장된 비트맵 파일을 불러온다. 파일이 없으면 null 반환. */
@@ -111,7 +113,10 @@ object PretendardBitmapRenderer {
         strikethrough: Boolean = false,
     ) {
         val bitmap = renderText(context, text, weight, sizeSp, textColorArgb, maxWidthPx, maxLines, strikethrough)
-        saveBitmap(context, bitmap, filename)
-        bitmap.recycle()
+        try {
+            saveBitmap(context, bitmap, filename)
+        } finally {
+            bitmap.recycle()
+        }
     }
 }

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/PretendardBitmapRenderer.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/PretendardBitmapRenderer.kt
@@ -1,0 +1,117 @@
+package com.tgyuu.ebbingplanner.widget.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.text.TextUtils
+import androidx.core.content.res.ResourcesCompat
+import com.tgyuu.designsystem.R
+import java.io.File
+import kotlin.math.ceil
+
+object PretendardBitmapRenderer {
+
+    enum class Weight { BOLD, SEMI_BOLD, MEDIUM, REGULAR }
+
+    private val typefaceCache = mutableMapOf<Weight, Typeface?>()
+
+    private fun getTypeface(context: Context, weight: Weight): Typeface {
+        return typefaceCache.getOrPut(weight) {
+            val resId = when (weight) {
+                Weight.BOLD -> R.font.pretendard_bold
+                Weight.SEMI_BOLD -> R.font.pretendard_semi_bold
+                Weight.MEDIUM -> R.font.pretendard_medium
+                Weight.REGULAR -> R.font.pretendard_medium
+            }
+            runCatching { ResourcesCompat.getFont(context, resId) }.getOrNull()
+        } ?: Typeface.DEFAULT
+    }
+
+    /**
+     * 텍스트를 Pretendard 폰트로 렌더링한 Bitmap을 반환한다.
+     *
+     * @param maxWidthPx    줄바꿈 기준 너비(px). Int.MAX_VALUE 이면 텍스트 너비에 맞춘다.
+     * @param maxLines      최대 줄 수 (초과 시 말줄임표)
+     * @param strikethrough 취소선 여부
+     */
+    fun renderText(
+        context: Context,
+        text: String,
+        weight: Weight,
+        sizeSp: Float,
+        textColorArgb: Int,
+        maxWidthPx: Int = Int.MAX_VALUE,
+        maxLines: Int = 1,
+        strikethrough: Boolean = false,
+    ): Bitmap {
+        val dm = context.resources.displayMetrics
+        @Suppress("DEPRECATION")
+        val textSizePx = sizeSp * dm.scaledDensity
+
+        val paint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            typeface = getTypeface(context, weight)
+            textSize = textSizePx
+            color = textColorArgb
+            isStrikeThruText = strikethrough
+        }
+
+        val effectiveWidth = if (maxWidthPx == Int.MAX_VALUE) {
+            ceil(paint.measureText(text)).toInt().coerceAtLeast(1)
+        } else {
+            maxWidthPx
+        }
+
+        val layout = StaticLayout.Builder
+            .obtain(text, 0, text.length, paint, effectiveWidth)
+            .setMaxLines(maxLines)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+            .setIncludePad(false)
+            .build()
+
+        val bitmapWidth = effectiveWidth.coerceAtLeast(1)
+        val bitmapHeight = layout.height.coerceAtLeast(1)
+
+        val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        Canvas(bitmap).also { layout.draw(it) }
+        return bitmap
+    }
+
+    /** 렌더링 결과를 내부 저장소 파일로 저장한다. */
+    fun saveBitmap(context: Context, bitmap: Bitmap, filename: String): File {
+        val dir = File(context.filesDir, "widget_bitmaps").also { it.mkdirs() }
+        val file = File(dir, filename)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        return file
+    }
+
+    /** 저장된 비트맵 파일을 불러온다. 파일이 없으면 null 반환. */
+    fun loadBitmap(context: Context, filename: String): Bitmap? {
+        val file = File(context.filesDir, "widget_bitmaps/$filename")
+        if (!file.exists()) return null
+        return BitmapFactory.decodeFile(file.absolutePath)
+    }
+
+    /** [renderText] 후 [saveBitmap]을 한 번에 수행한다. */
+    fun renderAndSave(
+        context: Context,
+        text: String,
+        weight: Weight,
+        sizeSp: Float,
+        textColorArgb: Int,
+        filename: String,
+        maxWidthPx: Int = Int.MAX_VALUE,
+        maxLines: Int = 1,
+        strikethrough: Boolean = false,
+    ) {
+        val bitmap = renderText(context, text, weight, sizeSp, textColorArgb, maxWidthPx, maxLines, strikethrough)
+        saveBitmap(context, bitmap, filename)
+        bitmap.recycle()
+    }
+}


### PR DESCRIPTION
- Glance는 커스텀 폰트(`fontFamily`)를 지원하지 않아, Canvas + Pretendard Typeface로 텍스트를 Bitmap에 직접 렌더링하는 방식으로 우회
- Receiver의 `updateData()` 시점에 비트맵을 생성해 내부 저장소에 캐시, `provideGlance()`에서 로드해 `Image(ImageProvider(bitmap))`으로 표시
- 비트맵 파일이 없을 경우(첫 렌더링 등) Glance `Text()`로 자동 fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
* 캘린더 위젯의 헤더 및 요일 표시 렌더링 최적화로 성능 향상
* 오늘의 할일 위젯의 텍스트 표시 성능 개선
* 다크/라이트 모드에 맞춘 위젯 색상 자동 조정
* 위젯 전반의 시각적 일관성 및 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->