### PR TITLE
[chore] 위젯 할 일 목록 폰트 크기 및 컬러 막대 크기 조정

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -254,7 +254,7 @@ internal fun TodoItemRow(
         Spacer(
             modifier = GlanceModifier
                 .width(3.dp)
-                .height(14.dp)
+                .height(24.dp)
                 .cornerRadius(2.dp)
                 .background(ColorProvider(Color(todo.color), Color(todo.color)))
         )
@@ -268,7 +268,7 @@ internal fun TodoItemRow(
         } else {
             Text(
                 text = todo.title,
-                style = (if (todo.isDone) EbbingWidgetTypography.body14M else EbbingWidgetTypography.heading14SB).copy(
+                style = (if (todo.isDone) EbbingWidgetTypography.heading16SB else EbbingWidgetTypography.body16M).copy(
                     color = if (todo.isDone) LocalEbbingWidgetColors.current.textDisabled else LocalEbbingWidgetColors.current.textOnBackground,
                     textDecoration = if (todo.isDone) TextDecoration.LineThrough else null,
                 ),


### PR DESCRIPTION
## Summary
- 위젯 할 일 항목 폰트: `heading14SB` → `heading16SB`
- 좌측 테마 컬러 막대 높이: `14dp` → `24dp`
- `TodoItemRow`는 `CalendarWidget`, `TodayTodoWidget` 공통 사용으로 두 위젯 모두 적용됨

## Test plan
- [ ] TodayTodo 위젯에서 할 일 목록 폰트 크기 및 컬러 막대 확인
- [ ] Calendar 위젯에서 할 일 목록 폰트 크기 및 컬러 막대 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 투두 항목의 좌측 컬러 인디케이터 높이가 증가되었습니다.
* 투두 완료 상태를 표시하는 제목 텍스트 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->