### PR TITLE
[feature] 투데이 투두 위젯 정렬 순서를 홈화면 설정과 동기화

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -22,6 +22,7 @@ import com.tgyuu.designsystem.foundation.normalDarkColorScheme
 import com.tgyuu.designsystem.foundation.normalLightColorScheme
 import com.tgyuu.designsystem.foundation.sunsetDarkColorScheme
 import com.tgyuu.designsystem.foundation.sunsetLightColorScheme
+import com.tgyuu.domain.model.SortType
 import com.tgyuu.domain.model.Theme
 import com.tgyuu.domain.model.TodoSchedule
 import com.tgyuu.domain.repository.ConfigRepository
@@ -125,9 +126,16 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
         val theme = configRepository.getWidgetTheme().firstOrNull() ?: Theme.NORMAL
         val backgroundAlpha = configRepository.getWidgetBackgroundAlpha().firstOrNull() ?: 1f
         val textAlpha = configRepository.getWidgetTextAlpha().firstOrNull() ?: 1f
+        val sortType = configRepository.getSortType()
         val todoLists = todoRepository
             .loadSchedulesByDate(LocalDate.now())
-            .sortedWith(compareBy({ it.isDone }, { it.title }))
+            .sortedWith(
+                when (sortType) {
+                    SortType.CREATED -> compareBy({ it.isDone }, { it.createdAt })
+                    SortType.NAME -> compareBy({ it.isDone }, { it.title })
+                    SortType.PRIORITY -> compareBy({ it.isDone }, { it.priority })
+                }
+            )
 
         withContext(Dispatchers.IO) {
             generatePretendardBitmaps(context, theme, textAlpha, todoLists)


### PR DESCRIPTION
## Summary
- 투데이 투두 위젯의 할 일 목록 정렬 순서가 이름순으로 고정되어 있던 문제 수정
- `configRepository.getSortType()`을 사용해 홈화면에서 선택한 정렬 순서(생성순/이름순/우선순위순)를 위젯에도 반영

## Changes
- `TodayTodoWidgetReceiver.kt`: 고정 이름순 정렬 → `SortType` 기반 동적 정렬로 변경

## Test plan
- [ ] 홈화면에서 정렬 순서를 생성순으로 설정 후 위젯 확인
- [ ] 홈화면에서 정렬 순서를 이름순으로 설정 후 위젯 확인
- [ ] 홈화면에서 정렬 순서를 우선순위순으로 설정 후 위젯 확인