### PR TITLE
[Fix] 위젯 릴리즈 빌드 이슈 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
 }
 
 baselineProfile {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,13 @@
 
 # Generic TypeToken 클래스 보존
 -keep class * extends com.google.gson.reflect.TypeToken
+
+# Glance 위젯 ActionCallback 구현체 보존 (런타임에 클래스명으로 찾음)
+-keep class * extends androidx.glance.appwidget.action.ActionCallback { *; }
+
+# Glance 위젯 GlanceAppWidget / GlanceAppWidgetReceiver 보존
+-keep class * extends androidx.glance.appwidget.GlanceAppWidget { *; }
+-keep class * extends androidx.glance.appwidget.GlanceAppWidgetReceiver { *; }
+
+# Glance FontWeight 리플렉션 보존 (EbbingWidgetFontWeight.SemiBold)
+-keep class androidx.glance.text.FontWeight { *; }

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -234,15 +234,11 @@ private fun CalendarWidgetHeader(
             getEbbingDayOfWeek(mondayStart).forEachIndexed { index, dow ->
                 val dowBitmap = dowBitmaps.getOrNull(index)
                 if (dowBitmap != null) {
-                    Box(
-                        contentAlignment = Alignment.Center,
+                    Image(
+                        provider = ImageProvider(dowBitmap),
+                        contentDescription = dow.toKorean(),
                         modifier = GlanceModifier.defaultWeight(),
-                    ) {
-                        Image(
-                            provider = ImageProvider(dowBitmap),
-                            contentDescription = dow.toKorean(),
-                        )
-                    }
+                    )
                 } else {
                     Text(
                         text = dow.toKorean(),

--- a/feature/widget/src/main/res/values-night/colors.xml
+++ b/feature/widget/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widgetBackground_25">#40FFFFFF</color>
+    <color name="widgetBackground_50">#80FFFFFF</color>
+    <color name="widgetBackground_75">#BFFFFFFF</color>
+    <color name="widgetBackground_100">#FFFFFFFF</color>
+</resources>

--- a/feature/widget/src/main/res/values/colors.xml
+++ b/feature/widget/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widgetBackground_25">#40F4F6FA</color>
+    <color name="widgetBackground_50">#80F4F6FA</color>
+    <color name="widgetBackground_75">#BFF4F6FA</color>
+    <color name="widgetBackground_100">#FFF4F6FA</color>
+</resources>

--- a/feature/widget/src/main/res/values/strings.xml
+++ b/feature/widget/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">EbbingPlanner</string>
+</resources>


### PR DESCRIPTION
## Summary

- 릴리즈 빌드에서 위젯이 표시되지 않던 문제 수정 (ProGuard 규칙 누락)
- 릴리즈 빌드 시 `feature/widget` 모듈 리소스 누락 문제 수정
- CodeRabbit 리뷰 반영 (접근성, 스레딩, 원자적 파일 저장, 위젯 크기 기반 비트맵 계산)

## 변경 내역

| 파일 | 내용 |
|---|---|
| `app/proguard-rules.pro` | Glance `ActionCallback`, `GlanceAppWidget`, `GlanceAppWidgetReceiver`, `FontWeight` keep 규칙 추가 |
| `app/build.gradle.kts` | baselineProfile 플러그인 유지 |
| `feature/widget/.../values/strings.xml` | 릴리즈 빌드용 `app_name` 리소스 추가 |
| `feature/widget/.../values/colors.xml` | 릴리즈 빌드용 `widgetBackground_*` 색상 추가 (라이트/다크) |
| `CalendarWidget.kt` | dow 라벨 Box 중첩 제거, contentDescription 추가 |
| `CalendarWidgetReceiver.kt` | 비트맵 생성 Dispatchers.IO 이동 |
| `TodayTodoWidget.kt` | contentDescription 추가 |
| `TodayTodoWidgetReceiver.kt` | Dispatchers.IO 이동, 실제 위젯 너비 기반 비트맵 크기 계산 |
| `PretendardBitmapRenderer.kt` | 원자적 파일 저장, bitmap.recycle() finally 처리 |

## Test plan

- [ ] 릴리즈 빌드에서 위젯 정상 표시 확인
- [ ] 라이트/다크 모드 전환 시 위젯 색상 확인
- [ ] 투두 체크 시 위젯 업데이트 확인