### PR TITLE
[Fix] : Remote Config 실험군 변경이 로컬에 반영되지 않던 버그 수정

### DIFF
--- a/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentLocalDataSource.kt
+++ b/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentLocalDataSource.kt
@@ -2,5 +2,5 @@ package com.tgyuu.experiment.data.datasource
 
 interface ExperimentLocalDataSource {
     suspend fun getAssignment(experimentKey: String): String?
-    suspend fun saveAssignmentIfNotExists(experimentKey: String, variantName: String)
+    suspend fun saveAssignment(experimentKey: String, variantName: String)
 }

--- a/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentLocalDataSourceImpl.kt
+++ b/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentLocalDataSourceImpl.kt
@@ -17,15 +17,13 @@ class ExperimentLocalDataSourceImpl @Inject constructor(
         return dataStore.data.first()[key]
     }
 
-    override suspend fun saveAssignmentIfNotExists(
+    override suspend fun saveAssignment(
         experimentKey: String,
         variantName: String,
     ) {
         val key = stringPreferencesKey("$EXPERIMENT_PREFIX$experimentKey")
         dataStore.edit { prefs ->
-            if (prefs[key] == null) {
-                prefs[key] = variantName
-            }
+            prefs[key] = variantName
         }
     }
 

--- a/core/experiment/data/src/main/java/com/tgyuu/experiment/data/repository/ExperimentRepositoryImpl.kt
+++ b/core/experiment/data/src/main/java/com/tgyuu/experiment/data/repository/ExperimentRepositoryImpl.kt
@@ -24,10 +24,9 @@ class ExperimentRepositoryImpl @Inject constructor(
 
         Experiment.ALL.forEach { experiment ->
             val remoteVariant = remoteVariants[experiment.key]
-            val variantToAssign = remoteVariant ?: experiment.defaultVariant.key
 
-            // 로컬에 없으면 로컬 저장
-            localDataSource.saveAssignmentIfNotExists(
+            val variantToAssign = remoteVariant ?: experiment.defaultVariant.key
+            localDataSource.saveAssignment(
                 experimentKey = experiment.key,
                 variantName = variantToAssign,
             )
@@ -56,7 +55,7 @@ class ExperimentRepositoryImpl @Inject constructor(
             variantName = remoteVariant ?: experiment.defaultVariant.key
 
             // 가져온 데이터 로컬 저장
-            localDataSource.saveAssignmentIfNotExists(
+            localDataSource.saveAssignment(
                 experimentKey = experiment.key,
                 variantName = variantName,
             )

--- a/core/experiment/data/src/test/java/com/tgyuu/experiment/data/repository/ExperimentRepositoryImplTest.kt
+++ b/core/experiment/data/src/test/java/com/tgyuu/experiment/data/repository/ExperimentRepositoryImplTest.kt
@@ -47,7 +47,7 @@ class ExperimentRepositoryImplTest {
     fun `메모리 캐시가 비어있으면 로컬에서 가져온다`() = runTest {
         // Given
         val experimentKey = Experiment.SaveButtonPosition.key
-        localDataSource.saveAssignmentIfNotExists(experimentKey, "CONTROL")
+        localDataSource.saveAssignment(experimentKey, "CONTROL")
 
         // When
         val result = repository.getVariant(Experiment.SaveButtonPosition)
@@ -122,18 +122,18 @@ class ExperimentRepositoryImplTest {
     }
 
     @Test
-    fun `fetchAndAssignExperiments는 저장 후 로컬의 실제 값을 메모리에 저장한다`() = runTest {
+    fun `fetchAndAssignExperiments는 리모트 값으로 로컬과 메모리를 갱신한다`() = runTest {
         // Given
         val experimentKey = Experiment.SaveButtonPosition.key
-        localDataSource.saveAssignmentIfNotExists(experimentKey, "CONTROL")
+        localDataSource.saveAssignment(experimentKey, "CONTROL")
         remoteDataSource.setRemoteVariant(experimentKey, "TREATMENT")
 
         // When
         repository.fetchAndAssignExperiments()
 
         // Then
-        assertEquals("CONTROL", localDataSource.getAssignment(experimentKey))
-        assertEquals("CONTROL", memoryDataSource.getAssignment(experimentKey))
+        assertEquals("TREATMENT", localDataSource.getAssignment(experimentKey))
+        assertEquals("TREATMENT", memoryDataSource.getAssignment(experimentKey))
     }
 
     @Test
@@ -141,7 +141,7 @@ class ExperimentRepositoryImplTest {
         // Given
         val experimentKey = Experiment.SaveButtonPosition.key
         memoryDataSource.saveAssignment(experimentKey, "TREATMENT")
-        localDataSource.saveAssignmentIfNotExists(experimentKey, "CONTROL")
+        localDataSource.saveAssignment(experimentKey, "CONTROL")
         remoteDataSource.setRemoteVariant(experimentKey, "TREATMENT")
 
         // When
@@ -178,10 +178,8 @@ class FakeExperimentLocalDataSource : ExperimentLocalDataSource {
         return storage[experimentKey]
     }
 
-    override suspend fun saveAssignmentIfNotExists(experimentKey: String, variantName: String) {
-        if (!storage.containsKey(experimentKey)) {
-            storage[experimentKey] = variantName
-        }
+    override suspend fun saveAssignment(experimentKey: String, variantName: String) {
+        storage[experimentKey] = variantName
     }
 }
 


### PR DESCRIPTION
## Summary
- `saveAssignmentIfNotExists`로 인해 최초 저장된 CONTROL 값이 이후 Remote Config에서 TREATMENT로 변경되어도 덮어쓰지 않던 버그 수정
- `saveAssignmentIfNotExists` 제거하고 `saveAssignment`(항상 덮어쓰기)로 통일
- 테스트 케이스도 올바른 동작으로 수정

## Test plan
- [ ] Remote Config에 TREATMENT 설정 후 앱 재실행 시 TREATMENT 반영 확인
- [ ] 기존 CONTROL 유저가 TREATMENT로 전환되는지 확인
- [ ] 단위 테스트 통과 확인