### PR TITLE
fix : 위젯 체크 빠르게 토글 시 텍스트-체크 상태 불일치 수정

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -27,6 +27,7 @@ import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -48,6 +49,7 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = CalendarWidget()
 
     private val scope = MainScope()
+    private var updateJob: Job? = null
 
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
@@ -74,7 +76,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
                 analyticsHelper.logEvent(
                     AnalyticsEvent.Click(screenName = "CalendarWidget", buttonName = "Refresh")
                 )
-                scope.launch {
+                updateJob?.cancel()
+                updateJob = scope.launch {
                     try {
                         updateDataInternal(context)
                     } finally {
@@ -86,7 +89,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
     }
 
     private fun updateData(context: Context) {
-        scope.launch { updateDataInternal(context) }
+        updateJob?.cancel()
+        updateJob = scope.launch { updateDataInternal(context) }
     }
 
     private suspend fun updateDataInternal(context: Context) {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -27,6 +27,7 @@ import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -48,6 +49,7 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = TodayTodoWidget()
 
     private val scope = MainScope()
+    private var updateJob: Job? = null
 
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
@@ -74,7 +76,8 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
                 analyticsHelper.logEvent(
                     AnalyticsEvent.Click(screenName = "TodoWidget", buttonName = "Refresh")
                 )
-                scope.launch {
+                updateJob?.cancel()
+                updateJob = scope.launch {
                     try {
                         updateDataInternal(context)
                     } finally {
@@ -92,7 +95,8 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
     }
 
     private fun updateData(context: Context) {
-        scope.launch { updateDataInternal(context) }
+        updateJob?.cancel()
+        updateJob = scope.launch { updateDataInternal(context) }
     }
 
     private suspend fun updateDataInternal(context: Context) {


### PR DESCRIPTION
## Summary
- 위젯에서 체크를 빠르게 반복 토글 시 텍스트 스타일(취소선/폰트)과 체크 상태가 불일치하던 버그 수정
- `TodayTodoWidgetReceiver`, `CalendarWidgetReceiver` 모두 적용

## 원인
- 체크 토글 시 `updateDataInternal()`이 동시에 여러 개 실행되면서, 비트맵 파일(IO)과 JSON 상태가 서로 다른 시점의 데이터를 반영
- 이전 업데이트 Job을 cancel하고 최신 상태만 반영하도록 수정

## Test plan
- [ ] 위젯에서 체크를 빠르게 반복 토글 시 텍스트 스타일(취소선)과 체크 상태가 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)