### PR TITLE
feat : TodayTodoWidget 새로고침 버튼 추가 및 모두 완료 시 헤더 취소선 적용

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidgetReceiver.kt
@@ -27,6 +27,7 @@ import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -48,6 +49,7 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = CalendarWidget()
 
     private val scope = MainScope()
+    private var updateJob: Job? = null
 
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
@@ -74,7 +76,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
                 analyticsHelper.logEvent(
                     AnalyticsEvent.Click(screenName = "CalendarWidget", buttonName = "Refresh")
                 )
-                scope.launch {
+                updateJob?.cancel()
+                updateJob = scope.launch {
                     try {
                         updateDataInternal(context)
                     } finally {
@@ -86,7 +89,8 @@ class CalendarWidgetReceiver : GlanceAppWidgetReceiver() {
     }
 
     private fun updateData(context: Context) {
-        scope.launch { updateDataInternal(context) }
+        updateJob?.cancel()
+        updateJob = scope.launch { updateDataInternal(context) }
     }
 
     private suspend fun updateDataInternal(context: Context) {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -55,6 +55,7 @@ import com.tgyuu.ebbingplanner.widget.util.AddTodoFromWidgetAction
 import com.tgyuu.ebbingplanner.widget.util.BaseWidgetPreview
 import com.tgyuu.ebbingplanner.widget.util.CheckTodoAction
 import com.tgyuu.ebbingplanner.widget.util.EbbingWidgetPreview
+import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import com.tgyuu.ebbingplanner.widget.util.GsonProvider
 import com.tgyuu.ebbingplanner.widget.util.TodayTodoBitmaps
 import com.tgyuu.ebbingplanner.widget.util.WidgetBitmapStore
@@ -129,6 +130,9 @@ private fun TodayTodoWidgetContent(
             modifier = GlanceModifier.fillMaxWidth(),
         ) {
             val todoListsDoneSize = todoLists.filter { it.isDone }.size
+            val isAllDone = todoLists.isNotEmpty() && todoListsDoneSize == todoLists.size
+            val headerColor = if (isAllDone) LocalEbbingWidgetColors.current.textDisabled
+                else LocalEbbingWidgetColors.current.textOnBackground
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -138,13 +142,14 @@ private fun TodayTodoWidgetContent(
                     Image(
                         provider = ImageProvider(bitmaps.header),
                         contentDescription = "오늘 할 일",
-                        colorFilter = ColorFilter.tint(LocalEbbingWidgetColors.current.textOnBackground),
+                        colorFilter = ColorFilter.tint(headerColor),
                     )
                 } else {
                     Text(
                         text = "오늘 할 일   ",
                         style = EbbingWidgetTypography.heading18B.copy(
-                            color = LocalEbbingWidgetColors.current.textOnBackground,
+                            color = headerColor,
+                            textDecoration = if (isAllDone) TextDecoration.LineThrough else null,
                         ),
                     )
                 }
@@ -192,6 +197,17 @@ private fun TodayTodoWidgetContent(
                             actionParametersOf(widgetSourceKey to "TodoWidget")
                         )
                     ),
+            )
+
+            Spacer(modifier = GlanceModifier.size(12.dp))
+
+            Image(
+                provider = ImageProvider(R.drawable.ic_widget_refresh),
+                contentDescription = null,
+                modifier = GlanceModifier
+                    .size(20.dp)
+                    .clickable(actionRunCallback<RefreshAction>()),
+                colorFilter = ColorFilter.tint(LocalEbbingWidgetColors.current.textSub),
             )
         }
 

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -288,6 +288,15 @@ internal fun TodoItemRow(
                     maxLines = 1,
                 )
             }
+
+            if (todo.isDone) {
+                Spacer(
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(LocalEbbingWidgetColors.current.textDisabled),
+                )
+            }
         }
 
         EbbingWidgetCheck(

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -27,6 +27,7 @@ import com.tgyuu.ebbingplanner.widget.util.PretendardBitmapRenderer
 import com.tgyuu.ebbingplanner.widget.util.RefreshAction
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -48,6 +49,7 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = TodayTodoWidget()
 
     private val scope = MainScope()
+    private var updateJob: Job? = null
 
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
@@ -74,7 +76,8 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
                 analyticsHelper.logEvent(
                     AnalyticsEvent.Click(screenName = "TodoWidget", buttonName = "Refresh")
                 )
-                scope.launch {
+                updateJob?.cancel()
+                updateJob = scope.launch {
                     try {
                         updateDataInternal(context)
                     } finally {
@@ -92,7 +95,8 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
     }
 
     private fun updateData(context: Context) {
-        scope.launch { updateDataInternal(context) }
+        updateJob?.cancel()
+        updateJob = scope.launch { updateDataInternal(context) }
     }
 
     private suspend fun updateDataInternal(context: Context) {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -189,15 +189,12 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
         )
 
         todoLists.take(MAX_VISIBLE_TODOS).forEachIndexed { index, todo ->
-            val weight = if (todo.isDone) PretendardBitmapRenderer.Weight.MEDIUM
-                         else PretendardBitmapRenderer.Weight.SEMI_BOLD
             PretendardBitmapRenderer.renderAndSave(
                 context, todo.title,
-                weight, 14f, white,
+                PretendardBitmapRenderer.Weight.SEMI_BOLD, 14f, white,
                 filename = "todo_title_$index.png",
                 maxWidthPx = titleMaxWidthPx,
                 maxLines = 1,
-                strikethrough = todo.isDone,
             )
         }
     }

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidgetReceiver.kt
@@ -157,13 +157,15 @@ class TodayTodoWidgetReceiver : GlanceAppWidgetReceiver() {
         // 외부 패딩(40dp) + 색상 바·패딩(15dp) + 체크 아이콘(20dp) + 이미지 내부 패딩(24dp) 제외
         val titleMaxWidthPx = ((minWidgetWidthDp - 99) * density).toInt().coerceAtLeast(50)
 
+        val doneSize = todoLists.count { it.isDone }
+        val isAllDone = todoLists.isNotEmpty() && doneSize == todoLists.size
+
         PretendardBitmapRenderer.renderAndSave(
             context, "오늘 할 일   ",
             PretendardBitmapRenderer.Weight.BOLD, 18f, white,
             filename = "todo_header.png",
+            strikethrough = isAllDone,
         )
-
-        val doneSize = todoLists.count { it.isDone }
         PretendardBitmapRenderer.renderAndSave(
             context, doneSize.toString(),
             PretendardBitmapRenderer.Weight.BOLD, 18f, white,

--- a/feature/widget/src/main/res/drawable/ic_widget_refresh.xml
+++ b/feature/widget/src/main/res/drawable/ic_widget_refresh.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M16.667,3.333v5h-5"
+      android:strokeWidth="1.667"
+      android:strokeColor="#5B5F72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"/>
+  <path
+      android:pathData="M14.767,12.5a5.833,5.833 0,1 1,-1.35,-6.067L16.667,8.333"
+      android:strokeWidth="1.667"
+      android:strokeColor="#5B5F72"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"/>
+</vector>


### PR DESCRIPTION
## Summary
- TodayTodoWidget에 새로고침 버튼(`ic_widget_refresh`) 추가
- 모든 할 일 완료 시 헤더 "오늘 할 일" 텍스트에 취소선 + disabled 색상 적용 (비트맵/폴백 모두)

## Test plan
- [ ] 위젯에서 새로고침 버튼 클릭 시 데이터가 갱신되는지 확인
- [ ] 모든 할 일을 완료했을 때 "오늘 할 일" 헤더에 취소선이 표시되는지 확인
- [ ] 완료 상태에서 하나라도 해제하면 취소선이 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 위젯 새로고침 버튼 추가

* **개선 사항**
  * 완료된 항목에 취소선 및 구분선 표시
  * 완료 상태에 따라 헤더 색상 동적 변경
  * 위젯 갱신 안정성 및 성능 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tgyuuAn/EbbingPlanner/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->