### PR TITLE
[Fix] : 실험군 variant 대소문자 불일치로 항상 CONTROL 반환되던 버그 수정

### DIFF
--- a/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentRemoteDataSourceImpl.kt
+++ b/core/experiment/data/src/main/java/com/tgyuu/experiment/data/datasource/ExperimentRemoteDataSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.tgyuu.experiment.data.datasource
 
-import android.util.Log
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.tgyuu.experiment.data.BuildConfig
 import com.tgyuu.experiment.data.datasource.ExperimentRemoteDataSource
@@ -21,14 +20,12 @@ class ExperimentRemoteDataSourceImpl @Inject constructor(
                     experimentKeys.forEach { key ->
                         val configKey = getConfigKey(key)
                         val value = remoteConfig.getString(configKey)
-                        Log.d("test", "key : $key value : $value")
 
                         if (value.isNotEmpty()) {
                             result[key] = value
                         }
                     }
                 }
-
                 continuation.resume(result)
             }
         }

--- a/core/experiment/domain/src/main/java/com/tgyuu/experiment/domain/model/Experiment.kt
+++ b/core/experiment/domain/src/main/java/com/tgyuu/experiment/domain/model/Experiment.kt
@@ -9,7 +9,8 @@ sealed class Experiment<V>(
     val defaultVariant: V,
 ) where V : Enum<V>, V : ExperimentVariant {
 
-    fun parseVariant(value: String): V = variants.find { it.key == value } ?: defaultVariant
+    fun parseVariant(value: String): V =
+        variants.find { it.key.equals(value, ignoreCase = true) } ?: defaultVariant
 
     data object SaveButtonPosition : Experiment<SaveButtonPosition.Variant>(
         key = "experiment_save_button_position",


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용 
- Firebase RemoteConfig에서는 대문자로 내려주고 있었는데, 앱에서는 소문자로 파싱하고 있었음둥