### PR TITLE
[Fix] 증분 동기화 시 FK 제약조건 위반 방지

### DIFF
--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -187,6 +187,9 @@ class SyncRepositoryImpl @Inject constructor(
 
         response.todoInfos.forEach { dto ->
             val todoInfo = dto.toDomain()
+            val tagExists = localTagDataSource.getTag(todoInfo.tagId) != null
+            if (!tagExists) return@forEach
+
             val local = localTodoDataSource.getTodoInfoEntity(todoInfo.id)
 
             if (local == null) {
@@ -200,6 +203,9 @@ class SyncRepositoryImpl @Inject constructor(
             val schedule = dto.toDomain()
 
             if (!schedule.isDeleted) {
+                val infoExists = localTodoDataSource.getTodoInfoEntity(schedule.infoId) != null
+                if (!infoExists) return@forEach
+
                 val local = localTodoDataSource.getTodoScheduleEntity(schedule.id)
 
                 if (local == null) {

--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
@@ -15,6 +15,8 @@ import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
+private const val CALENDAR_PAGE_COUNT = 12_001 // ±500년(월), ±115년(주)
+
 @Composable
 fun EbbingCalendar(
     calendarState: CalendarState,
@@ -27,17 +29,17 @@ fun EbbingCalendar(
     onGotoTodayClick: () -> Unit = {},
     onSyncClick: () -> Unit = {},
 ) {
-    val monthInitialPage = Int.MAX_VALUE / 2
+    val monthInitialPage = CALENDAR_PAGE_COUNT / 2
     val monthPagerState = rememberPagerState(
         initialPage = monthInitialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { CALENDAR_PAGE_COUNT },
     )
     val monthOffset = monthPagerState.currentPage - monthInitialPage
 
-    val weekInitialPage = Int.MAX_VALUE / 2
+    val weekInitialPage = CALENDAR_PAGE_COUNT / 2
     val weekPagerState = rememberPagerState(
         initialPage = weekInitialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { CALENDAR_PAGE_COUNT },
     )
     val weekOffset = weekPagerState.currentPage - weekInitialPage
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
@@ -43,6 +43,8 @@ import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.SortType
 import java.time.LocalDate
 
+private const val TODO_LIST_PAGE_COUNT = 12_001 // ±16년(일)
+
 @Composable
 internal fun EbbingTodoList(
     sortType: SortType,
@@ -56,10 +58,10 @@ internal fun EbbingTodoList(
     onSortTypeClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val initialPage = Int.MAX_VALUE / 2
+    val initialPage = TODO_LIST_PAGE_COUNT / 2
     val pagerState = rememberPagerState(
         initialPage = initialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { TODO_LIST_PAGE_COUNT },
     )
 
     var prevPage by remember { mutableIntStateOf(initialPage) }


### PR DESCRIPTION
## Summary
- 증분 동기화(incremental sync) 시 parent 엔티티가 로컬 DB에 없는 경우 `SQLiteConstraintException: FOREIGN KEY constraint failed` 발생하는 버그 수정
- `todoInfo` insert 전 참조하는 `todo_tag` 존재 여부 확인, 없으면 skip
- `schedule` insert 전 참조하는 `todo_info` 존재 여부 확인, 없으면 skip
- skip된 항목은 다음 sync cycle에서 parent가 동기화된 후 정상 반영됨

## Test plan
- [ ] 이전 버전 DB에서 업그레이드 후 동기화 시 크래시 없이 정상 동작 확인
- [ ] 정상 동기화 흐름에서 데이터 누락 없이 동기화되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 데이터 동기화 과정에서 관련된 선행 데이터의 존재 여부를 사전에 확인하도록 개선했습니다. 연결된 데이터가 로컬에 없는 경우 해당 항목을 건너뛰므로, 동기화 중 발생할 수 있는 오류를 방지합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tgyuuAn/EbbingPlanner/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->