### PR TITLE
[Fix] HorizontalPager OOM 방지

### DIFF
--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/calendar/Calendar.kt
@@ -15,6 +15,8 @@ import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 
+private const val CALENDAR_PAGE_COUNT = 12_001 // ±500년(월), ±115년(주)
+
 @Composable
 fun EbbingCalendar(
     calendarState: CalendarState,
@@ -27,17 +29,17 @@ fun EbbingCalendar(
     onGotoTodayClick: () -> Unit = {},
     onSyncClick: () -> Unit = {},
 ) {
-    val monthInitialPage = Int.MAX_VALUE / 2
+    val monthInitialPage = CALENDAR_PAGE_COUNT / 2
     val monthPagerState = rememberPagerState(
         initialPage = monthInitialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { CALENDAR_PAGE_COUNT },
     )
     val monthOffset = monthPagerState.currentPage - monthInitialPage
 
-    val weekInitialPage = Int.MAX_VALUE / 2
+    val weekInitialPage = CALENDAR_PAGE_COUNT / 2
     val weekPagerState = rememberPagerState(
         initialPage = weekInitialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { CALENDAR_PAGE_COUNT },
     )
     val weekOffset = weekPagerState.currentPage - weekInitialPage
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
@@ -43,6 +43,8 @@ import com.tgyuu.designsystem.model.TodoScheduleUiModel
 import com.tgyuu.domain.model.SortType
 import java.time.LocalDate
 
+private const val TODO_LIST_PAGE_COUNT = 12_001 // ±16년(일)
+
 @Composable
 internal fun EbbingTodoList(
     sortType: SortType,
@@ -56,10 +58,10 @@ internal fun EbbingTodoList(
     onSortTypeClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val initialPage = Int.MAX_VALUE / 2
+    val initialPage = TODO_LIST_PAGE_COUNT / 2
     val pagerState = rememberPagerState(
         initialPage = initialPage,
-        pageCount = { Int.MAX_VALUE },
+        pageCount = { TODO_LIST_PAGE_COUNT },
     )
 
     var prevPage by remember { mutableIntStateOf(initialPage) }


### PR DESCRIPTION
## Summary
- `HorizontalPager(pageCount = Int.MAX_VALUE)` → `12_001`로 축소
- Pager 내부 자료구조 메모리 부담 감소로 `Recomposer.getKnownCompositions`에서 발생하는 OOM 방지
- ±500년(월간)/±16년(일간) 범위로 실사용에 충분

## 수정 파일
- `Calendar.kt` — 월간/주간 Pager
- `EbbingTodoList.kt` — 투두 리스트 Pager

## Test plan
- [ ] 캘린더 월간/주간 스와이프 정상 동작 확인
- [ ] 투두 리스트 좌우 스와이프 정상 동작 확인
- [ ] 장시간 스와이프 시 메모리 사용량 안정적인지 확인