### PR TITLE
feat: 알림 설정 Firestore silent 로깅

### DIFF
--- a/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.data.repository
 
+import com.tgyuu.datastore.datasource.sync.LocalSyncDataSource
 import com.tgyuu.datastore.datasource.user.LocalUserConfigDataSource
 import com.tgyuu.domain.model.CalendarDefaultView
 import com.tgyuu.domain.model.SortType
@@ -8,6 +9,7 @@ import com.tgyuu.domain.model.UpdateInfo
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.network.model.GetUpdateInfoResponse
 import com.tgyuu.network.source.ConfigDataSource
+import com.tgyuu.network.source.NotificationLogDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
@@ -15,6 +17,8 @@ import javax.inject.Inject
 class ConfigRepositoryImpl @Inject constructor(
     private val localUserConfigDataSource: LocalUserConfigDataSource,
     private val configDataSource: ConfigDataSource,
+    private val notificationLogDataSource: NotificationLogDataSource,
+    private val localSyncDataSource: LocalSyncDataSource,
 ) : ConfigRepository {
     override suspend fun isFirstAppOpen(): Boolean =
         localUserConfigDataSource.consumeIsFirstAppOpen()
@@ -29,8 +33,10 @@ class ConfigRepositoryImpl @Inject constructor(
     override suspend fun getNotificationEnabled(): Flow<Boolean> =
         localUserConfigDataSource.notificationEnabled
 
-    override suspend fun setNotificationEnabled(enabled: Boolean) =
+    override suspend fun setNotificationEnabled(enabled: Boolean) {
         localUserConfigDataSource.setNotificationEnabled(enabled)
+        logNotificationConfigSilently()
+    }
 
     override suspend fun setAppTheme(theme: Theme) = localUserConfigDataSource.setAppTheme(theme)
     override suspend fun setWidgetTheme(theme: Theme) =
@@ -48,8 +54,10 @@ class ConfigRepositoryImpl @Inject constructor(
     override suspend fun getAlarmTime(): Pair<Int, Int> =
         localUserConfigDataSource.alarmTime.first()
 
-    override suspend fun updateAlarmMessage(message: String) =
+    override suspend fun updateAlarmMessage(message: String) {
         localUserConfigDataSource.setAlarmMessage(message)
+        logNotificationConfigSilently()
+    }
 
     override suspend fun getAlarmMessage(): String =
         localUserConfigDataSource.alarmMessage.first()
@@ -96,4 +104,20 @@ class ConfigRepositoryImpl @Inject constructor(
 
     override suspend fun setCalendarDefaultView(view: CalendarDefaultView) =
         localUserConfigDataSource.setCalendarDefaultView(view)
+
+    private suspend fun logNotificationConfigSilently() = runCatching {
+        val uuid = localSyncDataSource.uuid.first()
+        val enabled = localUserConfigDataSource.notificationEnabled.first()
+        val (hour, minute) = localUserConfigDataSource.alarmTime.first()
+        val message = localUserConfigDataSource.alarmMessage.first()
+
+        notificationLogDataSource.logNotificationConfig(
+            uuid = uuid,
+            enabled = enabled,
+            alarmTime = String.format("%02d:%02d", hour, minute),
+            messageLength = message.length,
+            usesPlaceholder = message.contains("{할일}"),
+            isDefault = message == ConfigRepository.DEFAULT_ALARM_MESSAGE,
+        )
+    }
 }

--- a/core/network/src/main/java/com/tgyuu/network/source/NotificationLogDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/NotificationLogDataSource.kt
@@ -1,0 +1,37 @@
+package com.tgyuu.network.source
+
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class NotificationLogDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore,
+) {
+    suspend fun logNotificationConfig(
+        uuid: String,
+        enabled: Boolean,
+        alarmTime: String,
+        messageLength: Int,
+        usesPlaceholder: Boolean,
+        isDefault: Boolean,
+    ) {
+        val data = mapOf(
+            "notificationEnabled" to enabled,
+            "alarmTime" to alarmTime,
+            "messageLength" to messageLength,
+            "usesPlaceholder" to usesPlaceholder,
+            "isDefaultMessage" to isDefault,
+            "updatedAt" to FieldValue.serverTimestamp(),
+        )
+
+        firestore.collection(COLLECTION_ANALYTICS)
+            .document(uuid)
+            .set(data)
+            .await()
+    }
+
+    private companion object {
+        private const val COLLECTION_ANALYTICS = "notificationAnalytics"
+    }
+}


### PR DESCRIPTION
## Summary
- 알림 설정(토글/시간/메시지) 변경 시 Firestore `notificationLogs/{uuid}`에 자동 업로드
- 실패해도 에러 무시 (silent) — 유저 알림 사용 패턴 분석 목적
- `NotificationLogDataSource` 별도 생성, `SyncDataSource`와 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 알림 설정 변경 시 자동 기록: 알림 활성화 여부, 알람 시간, 메시지 변경 사항이 자동으로 기록되도록 개선되었습니다. 이를 통해 알림 설정의 변경 이력을 추적하고 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->