### PR TITLE
fix: 위젯 넛징 다이얼로그 반복 노출 버그 수정

### DIFF
--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -91,7 +91,7 @@ internal fun HomeRoute(
         viewModel.initCurrentMonthSchedules()
     }
 
-    LaunchedEffect(showWidgetNudge) {
+    LaunchedEffect(Unit) {
         if (showWidgetNudge) {
             viewModel.showWidgetNudgeDialog()
         }


### PR DESCRIPTION
## Summary
- 첫 일정 등록 후 위젯 넛징 다이얼로그가 수정 페이지 갔다가 돌아와도 계속 뜨는 버그 수정
- 원인: `LaunchedEffect(showWidgetNudge)`가 recompose 시 재실행되어 다이얼로그가 반복 표시
- 수정: `LaunchedEffect(Unit)`으로 변경하여 최초 진입 시 한 번만 실행

<!-- end of auto-generated comment: release notes by coderabbit.ai -->