### PR TITLE
feat: onStop 시 자동 백업 기능 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,8 @@ dependencies {
     implementation(projects.feature.widget)
     baselineProfile(projects.baselineprofile)
 
+    testImplementation(libs.mockk)
+
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.profileinstaller)
     implementation(libs.androidx.adaptive.navigation.suite)

--- a/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.tgyuu.analytics.AnalyticsHelper
 import com.tgyuu.analytics.LocalAnalyticsHelper
+import com.tgyuu.ebbingplanner.backup.AutoBackupManager
 import com.tgyuu.analytics.TrackNavigationDestination
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EventBus
@@ -50,6 +51,7 @@ import com.tgyuu.navigation.NavigationEvent.To
 import com.tgyuu.navigation.SettingGraph
 import com.tgyuu.setting.BuildConfig
 import com.tgyuu.sync.network.NetworkMonitor
+import com.tgyuu.sync.network.NetworkState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -72,6 +74,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var analyticsHelper: AnalyticsHelper
 
+    @Inject
+    lateinit var autoBackupManager: AutoBackupManager
+
     private var isInitialized = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -84,6 +89,14 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             viewModel.initAppState()
             isInitialized = false
+        }
+
+        lifecycleScope.launch {
+            networkMonitor.networkState.collect { state ->
+                if (state == NetworkState.Connected) {
+                    autoBackupManager.tryPendingBackup()
+                }
+            }
         }
 
         setContent {
@@ -141,6 +154,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onStop() {
         super.onStop()
+        if (!isChangingConfigurations) {
+            lifecycleScope.launch { autoBackupManager.onAppStop() }
+        }
+
         sendBroadcast(
             Intent(this, TodayTodoWidgetReceiver::class.java).apply {
                 action = RefreshAction.UPDATE_ACTION

--- a/app/src/main/java/com/tgyuu/ebbingplanner/backup/AutoBackupManager.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/backup/AutoBackupManager.kt
@@ -1,0 +1,88 @@
+package com.tgyuu.ebbingplanner.backup
+
+import com.tgyuu.common.suspendRunCatching
+import com.tgyuu.domain.repository.ConfigRepository
+import com.tgyuu.domain.repository.FeatureFlag
+import com.tgyuu.domain.repository.FeatureFlagRepository
+import com.tgyuu.domain.repository.SyncRepository
+import com.tgyuu.sync.network.NetworkMonitor
+import com.tgyuu.sync.network.NetworkState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.ZonedDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutoBackupManager @Inject constructor(
+    private val syncRepository: SyncRepository,
+    private val configRepository: ConfigRepository,
+    private val networkMonitor: NetworkMonitor,
+    private val featureFlagRepository: FeatureFlagRepository,
+) {
+    private var backupJob: Job? = null
+
+    suspend fun onAppStop() {
+        if (!featureFlagRepository.getBoolean(FeatureFlag.USE_AUTO_BACKUP)) return
+
+        val enabled = configRepository.getAutoBackupEnabled().first()
+        if (!enabled) return
+
+        if (networkMonitor.networkState.value == NetworkState.Connected) {
+            if (!isCoolTimeElapsed()) {
+                syncRepository.setBackupPending(true)
+                return
+            }
+
+            cancelAndBackup()
+        } else {
+            syncRepository.setBackupPending(true)
+        }
+    }
+
+    suspend fun tryPendingBackup() {
+        if (!featureFlagRepository.getBoolean(FeatureFlag.USE_AUTO_BACKUP)) return
+
+        val enabled = configRepository.getAutoBackupEnabled().first()
+        if (!enabled) return
+
+        val pending = syncRepository.getBackupPending().first()
+        if (!pending) return
+
+        if (networkMonitor.networkState.value != NetworkState.Connected) return
+        if (!isCoolTimeElapsed()) return
+
+        cancelAndBackup()
+    }
+
+    private suspend fun cancelAndBackup() = coroutineScope {
+        backupJob?.cancel()
+        backupJob = launch {
+            suspendRunCatching {
+                syncRepository.syncUpData()
+            }.onSuccess {
+                syncRepository.setBackupPending(false)
+            }.onFailure {
+                syncRepository.setBackupPending(true)
+            }
+        }
+    }
+
+    private suspend fun isCoolTimeElapsed(): Boolean {
+        val serverLastUpdatedAt = suspendRunCatching {
+            syncRepository.getServerLastUpdatedAt()
+        }.getOrNull()
+            ?: return true
+
+        val elapsedMillis = Duration.between(serverLastUpdatedAt, ZonedDateTime.now()).toMillis()
+        if (elapsedMillis < 0) return true
+        return elapsedMillis >= SYNC_UP_COOL_TIME
+    }
+
+    private companion object {
+        const val SYNC_UP_COOL_TIME = 10_000L
+    }
+}

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/AutoBackupManagerTest.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/AutoBackupManagerTest.kt
@@ -1,0 +1,121 @@
+package com.tgyuu.ebbingplanner.backup
+
+import com.tgyuu.domain.repository.FeatureFlag
+import com.tgyuu.ebbingplanner.backup.fake.FakeConfigRepository
+import com.tgyuu.ebbingplanner.backup.fake.FakeFeatureFlagRepository
+import com.tgyuu.ebbingplanner.backup.fake.FakeSyncRepository
+import com.tgyuu.sync.network.NetworkMonitor
+import com.tgyuu.sync.network.NetworkState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+class AutoBackupManagerTest {
+    private lateinit var syncRepository: FakeSyncRepository
+    private lateinit var configRepository: FakeConfigRepository
+    private lateinit var featureFlagRepository: FakeFeatureFlagRepository
+    private lateinit var networkMonitor: NetworkMonitor
+    private lateinit var autoBackupManager: AutoBackupManager
+
+    private val networkState = MutableStateFlow<NetworkState>(NetworkState.Connected)
+
+    @BeforeEach
+    fun setUp() {
+        syncRepository = FakeSyncRepository()
+        configRepository = FakeConfigRepository()
+        featureFlagRepository = FakeFeatureFlagRepository()
+        networkMonitor = mockk {
+            every { this@mockk.networkState } returns this@AutoBackupManagerTest.networkState
+        }
+
+        featureFlagRepository.set(FeatureFlag.USE_AUTO_BACKUP, true)
+
+        autoBackupManager = AutoBackupManager(
+            syncRepository = syncRepository,
+            configRepository = configRepository,
+            networkMonitor = networkMonitor,
+            featureFlagRepository = featureFlagRepository,
+        )
+    }
+
+    @Test
+    fun `feature flag가 꺼져있으면 백업하지 않는다`() = runTest {
+        featureFlagRepository.set(FeatureFlag.USE_AUTO_BACKUP, false)
+
+        autoBackupManager.onAppStop()
+
+        assertEquals(0, syncRepository.syncUpCallCount)
+    }
+
+    @Test
+    fun `autoBackupEnabled가 꺼져있으면 백업하지 않는다`() = runTest {
+        configRepository.setAutoBackupEnabledValue(false)
+
+        autoBackupManager.onAppStop()
+
+        assertEquals(0, syncRepository.syncUpCallCount)
+    }
+
+    @Test
+    fun `네트워크 미연결 시 pending을 true로 설정한다`() = runTest {
+        networkState.value = NetworkState.NotConnected
+
+        autoBackupManager.onAppStop()
+
+        assertEquals(0, syncRepository.syncUpCallCount)
+        assertTrue(syncRepository.getBackupPending().first())
+    }
+
+    @Test
+    fun `cool time 미경과 시 pending을 true로 설정한다`() = runTest {
+        syncRepository.serverLastUpdatedAt = ZonedDateTime.now()
+
+        autoBackupManager.onAppStop()
+
+        assertEquals(0, syncRepository.syncUpCallCount)
+        assertTrue(syncRepository.getBackupPending().first())
+    }
+
+    @Test
+    fun `정상 조건에서 syncUpData를 호출하고 pending을 false로 설정한다`() = runTest {
+        autoBackupManager.onAppStop()
+
+        assertEquals(1, syncRepository.syncUpCallCount)
+        assertFalse(syncRepository.getBackupPending().first())
+    }
+
+    @Test
+    fun `syncUpData 실패 시 pending을 true로 설정한다`() = runTest {
+        syncRepository.shouldSyncFail = true
+
+        autoBackupManager.onAppStop()
+
+        assertEquals(1, syncRepository.syncUpCallCount)
+        assertTrue(syncRepository.getBackupPending().first())
+    }
+
+    @Test
+    fun `tryPendingBackup은 pending이 false면 백업하지 않는다`() = runTest {
+        autoBackupManager.tryPendingBackup()
+
+        assertEquals(0, syncRepository.syncUpCallCount)
+    }
+
+    @Test
+    fun `tryPendingBackup은 정상 조건에서 syncUpData를 호출하고 pending을 false로 설정한다`() = runTest {
+        syncRepository.setBackupPending(true)
+
+        autoBackupManager.tryPendingBackup()
+
+        assertEquals(1, syncRepository.syncUpCallCount)
+        assertFalse(syncRepository.getBackupPending().first())
+    }
+}

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeConfigRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeConfigRepository.kt
@@ -1,0 +1,54 @@
+package com.tgyuu.ebbingplanner.backup.fake
+
+import com.tgyuu.domain.model.CalendarDefaultView
+import com.tgyuu.domain.model.SortType
+import com.tgyuu.domain.model.Theme
+import com.tgyuu.domain.model.UpdateInfo
+import com.tgyuu.domain.repository.ConfigRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeConfigRepository : ConfigRepository {
+    private val _autoBackupEnabled = MutableStateFlow(true)
+
+    fun setAutoBackupEnabledValue(enabled: Boolean) {
+        _autoBackupEnabled.value = enabled
+    }
+
+    override fun getAutoBackupEnabled(): Flow<Boolean> = _autoBackupEnabled
+    override suspend fun setAutoBackupEnabled(enabled: Boolean) {
+        _autoBackupEnabled.value = enabled
+    }
+
+    override fun getAppTheme(): Flow<Theme> = flowOf(Theme.NORMAL)
+    override fun getWidgetTheme(): Flow<Theme> = flowOf(Theme.NORMAL)
+    override fun getWidgetBackgroundAlpha(): Flow<Float> = flowOf(1f)
+    override fun getWidgetTextAlpha(): Flow<Float> = flowOf(1f)
+    override suspend fun isFirstAppOpen(): Boolean = false
+    override suspend fun shouldShowNotificationNudge(): Boolean = false
+    override suspend fun setSortType(sortType: SortType) {}
+    override suspend fun getSortType(): SortType = SortType.CREATED
+    override suspend fun getNotificationEnabled(): Flow<Boolean> = flowOf(true)
+    override suspend fun setNotificationEnabled(enabled: Boolean) {}
+    override suspend fun setAppTheme(theme: Theme) {}
+    override suspend fun setWidgetTheme(theme: Theme) {}
+    override suspend fun setWidgetBackgroundAlpha(alpha: Float) {}
+    override suspend fun setWidgetTextAlpha(alpha: Float) {}
+    override suspend fun updateAlarmTime(hour: String, minute: String) {}
+    override suspend fun getAlarmTime(): Pair<Int, Int> = Pair(9, 0)
+    override suspend fun updateAlarmMessage(message: String) {}
+    override suspend fun getAlarmMessage(): String = ConfigRepository.DEFAULT_ALARM_MESSAGE
+    override suspend fun getSoftUpdateInfo(): UpdateInfo = UpdateInfo("1.0.0", "")
+    override suspend fun getHardUpdateInfo(): UpdateInfo = UpdateInfo("1.0.0", "")
+    override suspend fun getClearSyncFlag(): Boolean = false
+    override suspend fun consumeInAppReview(): Boolean = false
+    override suspend fun markFirstTodoAdded(): Boolean = false
+    override suspend fun incrementTodoRegisteredCount() {}
+    override fun getTodoRegisteredCount(): Flow<Int> = flowOf(0)
+    override fun getMondayStart(): Flow<Boolean> = flowOf(false)
+    override suspend fun setMondayStart(enabled: Boolean) {}
+    override fun getCalendarDefaultView(): Flow<CalendarDefaultView> =
+        flowOf(CalendarDefaultView.MONTHLY)
+    override suspend fun setCalendarDefaultView(view: CalendarDefaultView) {}
+}

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeFeatureFlagRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeFeatureFlagRepository.kt
@@ -1,0 +1,15 @@
+package com.tgyuu.ebbingplanner.backup.fake
+
+import com.tgyuu.domain.repository.FeatureFlagRepository
+
+class FakeFeatureFlagRepository : FeatureFlagRepository {
+    private val flags = mutableMapOf<String, Boolean>()
+
+    fun set(key: String, value: Boolean) {
+        flags[key] = value
+    }
+
+    override suspend fun fetchAndAwait() {}
+
+    override fun getBoolean(key: String): Boolean = flags[key] ?: false
+}

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
@@ -1,0 +1,41 @@
+package com.tgyuu.ebbingplanner.backup.fake
+
+import com.tgyuu.domain.model.sync.ConnectInfo
+import com.tgyuu.domain.repository.SyncRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.ZonedDateTime
+
+class FakeSyncRepository : SyncRepository {
+    var shouldSyncFail: Boolean = false
+    var syncUpCallCount: Int = 0
+    var serverLastUpdatedAt: ZonedDateTime? = null
+
+    private val _backupPending = MutableStateFlow(false)
+
+    override suspend fun ensureUUIDExists() {}
+    override suspend fun getUuid(): String = "test-uuid"
+    override suspend fun getConnectedUuid(): String? = null
+    override suspend fun getServerLastUpdatedAt(): ZonedDateTime? = serverLastUpdatedAt
+    override suspend fun getLocalSyncedAt(): ZonedDateTime? = null
+
+    override suspend fun syncUpData(): ZonedDateTime {
+        syncUpCallCount++
+        if (shouldSyncFail) throw Exception("sync failed")
+        return ZonedDateTime.now()
+    }
+
+    override suspend fun generateConnectCode(connectCode: String): ZonedDateTime =
+        ZonedDateTime.now()
+
+    override suspend fun getMyConnectCode(): String? = null
+    override suspend fun getConnectCodeExpiration(): ZonedDateTime? = null
+    override suspend fun connectAnother(connectCode: String): ConnectInfo? = null
+    override suspend fun disconnectAnother() {}
+
+    override fun getBackupPending(): Flow<Boolean> = _backupPending
+
+    override suspend fun setBackupPending(pending: Boolean) {
+        _backupPending.value = pending
+    }
+}

--- a/core/data/src/main/java/com/tgyuu/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/tgyuu/data/di/DataModule.kt
@@ -2,10 +2,12 @@ package com.tgyuu.data.di
 
 import com.tgyuu.data.repository.ConfigRepositoryImpl
 import com.tgyuu.data.repository.ErrorRepositoryImpl
+import com.tgyuu.data.repository.FeatureFlagRepositoryImpl
 import com.tgyuu.data.repository.SyncRepositoryImpl
 import com.tgyuu.data.repository.TodoRepositoryImpl
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.ErrorRepository
+import com.tgyuu.domain.repository.FeatureFlagRepository
 import com.tgyuu.domain.repository.SyncRepository
 import com.tgyuu.domain.repository.TodoRepository
 import dagger.Binds
@@ -33,4 +35,8 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindErrorRepository(errorRepositoryImpl: ErrorRepositoryImpl): ErrorRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindFeatureFlagRepository(featureFlagRepositoryImpl: FeatureFlagRepositoryImpl): FeatureFlagRepository
 }

--- a/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
@@ -105,6 +105,12 @@ class ConfigRepositoryImpl @Inject constructor(
     override suspend fun setCalendarDefaultView(view: CalendarDefaultView) =
         localUserConfigDataSource.setCalendarDefaultView(view)
 
+    override fun getAutoBackupEnabled(): Flow<Boolean> =
+        localUserConfigDataSource.autoBackupEnabled
+
+    override suspend fun setAutoBackupEnabled(enabled: Boolean) =
+        localUserConfigDataSource.setAutoBackupEnabled(enabled)
+
     private suspend fun logNotificationConfigSilently() = runCatching {
         val uuid = localSyncDataSource.uuid.first()
         val enabled = localUserConfigDataSource.notificationEnabled.first()

--- a/core/data/src/main/java/com/tgyuu/data/repository/FeatureFlagRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/FeatureFlagRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.tgyuu.data.repository
+
+import com.tgyuu.domain.repository.FeatureFlagRepository
+import com.tgyuu.network.source.FeatureFlagDataSource
+import javax.inject.Inject
+
+class FeatureFlagRepositoryImpl @Inject constructor(
+    private val featureFlagDataSource: FeatureFlagDataSource,
+) : FeatureFlagRepository {
+    override suspend fun fetchAndAwait() = featureFlagDataSource.fetchAndAwait()
+
+    override fun getBoolean(key: String): Boolean =
+        featureFlagDataSource.getBoolean(key)
+}

--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.tgyuu.domain.repository.SyncRepository
 import com.tgyuu.network.source.SyncRemoteDataSource
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -277,6 +278,11 @@ class SyncRepositoryImpl @Inject constructor(
         localSyncDataSource.setLastSyncTime(response.syncedAt)
         response.syncedAt
     }
+
+    override fun getBackupPending(): Flow<Boolean> = localSyncDataSource.backupPending
+
+    override suspend fun setBackupPending(pending: Boolean) =
+        localSyncDataSource.setBackupPending(pending)
 
     private companion object {
         val EPOCH: LocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 0)

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSource.kt
@@ -15,4 +15,6 @@ interface LocalSyncDataSource {
     suspend fun setConnectCode(linkCode: String?)
     suspend fun setLastSyncTime(time: ZonedDateTime?)
     suspend fun setConnectCodeExpirationTime(time: ZonedDateTime?)
+    val backupPending: Flow<Boolean>
+    suspend fun setBackupPending(pending: Boolean)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/sync/LocalSyncDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.tgyuu.datastore.datasource.sync
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
@@ -86,11 +87,20 @@ class LocalSyncDataSourceImpl @Inject constructor(
         }
     }
 
+    override val backupPending: Flow<Boolean>
+        get() = dataStore.data
+            .map { prefs -> prefs[BACKUP_PENDING] ?: false }
+
+    override suspend fun setBackupPending(pending: Boolean) {
+        dataStore.edit { prefs -> prefs[BACKUP_PENDING] = pending }
+    }
+
     companion object {
         private val UUID = stringPreferencesKey("UUID")
         private val CONNECTED_UUID = stringPreferencesKey("CONNECTED_UUID")
         private val LAST_SYNC_TIME = stringPreferencesKey("LAST_SYNC_TIME")
         private val CONNECT_CODE = stringPreferencesKey("CONNECT_CODE")
         private val CONNECT_CODE_EXPIRATION_TIME = stringPreferencesKey("CODE_EXPIRATION_TIME")
+        private val BACKUP_PENDING = booleanPreferencesKey("BACKUP_PENDING")
     }
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
@@ -33,4 +33,6 @@ interface LocalUserConfigDataSource {
     suspend fun setMondayStart(enabled: Boolean)
     val calendarDefaultView: Flow<CalendarDefaultView>
     suspend fun setCalendarDefaultView(view: CalendarDefaultView)
+    val autoBackupEnabled: Flow<Boolean>
+    suspend fun setAutoBackupEnabled(enabled: Boolean)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
@@ -144,6 +144,14 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         dataStore.edit { prefs -> prefs[CALENDAR_DEFAULT_VIEW] = view.name }
     }
 
+    override val autoBackupEnabled: Flow<Boolean>
+        get() = dataStore.data
+            .map { prefs -> prefs[AUTO_BACKUP_ENABLED] ?: true }
+
+    override suspend fun setAutoBackupEnabled(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[AUTO_BACKUP_ENABLED] = enabled }
+    }
+
     override suspend fun consumeInAppReview(): Boolean {
         var shouldShow = false
         dataStore.edit { prefs ->
@@ -192,5 +200,6 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         private val TODO_REGISTERED_COUNT = intPreferencesKey("TODO_REGISTERED_COUNT")
         private val MONDAY_START = booleanPreferencesKey("MONDAY_START")
         private val CALENDAR_DEFAULT_VIEW = stringPreferencesKey("CALENDAR_DEFAULT_VIEW")
+        private val AUTO_BACKUP_ENABLED = booleanPreferencesKey("AUTO_BACKUP_ENABLED")
     }
 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="setting_version">현재 버전 정보 %1$s</string>
     <string name="setting_inquiry">문의</string>
     <string name="setting_contact_us">문의하기</string>
+    <string name="setting_auto_backup">자동 백업</string>
+    <string name="setting_last_sync_time">마지막 동기화: %1$s</string>
 
     <string name="onboarding_1_title">하루 만에 60%가 사라집니다</string>
     <string name="onboarding_1_description">Hermann Ebbinghaus의 연구에 따르면, 복습하지 않으면\n하루 만에 기억의 60% 이상이 소실됩니다.</string>

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
@@ -37,6 +37,8 @@ interface ConfigRepository {
     suspend fun setMondayStart(enabled: Boolean)
     fun getCalendarDefaultView(): Flow<CalendarDefaultView>
     suspend fun setCalendarDefaultView(view: CalendarDefaultView)
+    fun getAutoBackupEnabled(): Flow<Boolean>
+    suspend fun setAutoBackupEnabled(enabled: Boolean)
 
     companion object {
         const val DEFAULT_ALARM_MESSAGE: String = "{할일} 을 확인하고, 잊지 말고 복습하세요!"

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/FeatureFlag.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/FeatureFlag.kt
@@ -1,0 +1,6 @@
+package com.tgyuu.domain.repository
+
+object FeatureFlag {
+    const val USE_SUPABASE_SYNC = "sync_use_supabase"
+    const val USE_AUTO_BACKUP = "use_auto_backup"
+}

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/FeatureFlagRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/FeatureFlagRepository.kt
@@ -1,0 +1,6 @@
+package com.tgyuu.domain.repository
+
+interface FeatureFlagRepository {
+    suspend fun fetchAndAwait()
+    fun getBoolean(key: String): Boolean
+}

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
@@ -1,6 +1,7 @@
 package com.tgyuu.domain.repository
 
 import com.tgyuu.domain.model.sync.ConnectInfo
+import kotlinx.coroutines.flow.Flow
 import java.time.ZonedDateTime
 
 interface SyncRepository {
@@ -15,4 +16,6 @@ interface SyncRepository {
     suspend fun getConnectCodeExpiration(): ZonedDateTime?
     suspend fun connectAnother(connectCode: String): ConnectInfo?
     suspend fun disconnectAnother()
+    fun getBackupPending(): Flow<Boolean>
+    suspend fun setBackupPending(pending: Boolean)
 }

--- a/core/network/src/main/java/com/tgyuu/network/source/DelegatingSyncDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/DelegatingSyncDataSource.kt
@@ -5,6 +5,7 @@ import com.tgyuu.domain.model.sync.RepeatCycleForSync
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import com.tgyuu.domain.model.sync.TodoTagForSync
+import com.tgyuu.domain.repository.FeatureFlag
 import com.tgyuu.network.source.firestore.FirestoreSyncDataSource
 import java.time.ZonedDateTime
 import java.util.Date
@@ -19,7 +20,7 @@ class DelegatingSyncDataSource @Inject constructor(
 ) : SyncRemoteDataSource {
 
     private val delegate: SyncRemoteDataSource
-        get() = if (featureFlagDataSource.getBooleanSync(FeatureFlagDataSource.USE_SUPABASE_SYNC)) {
+        get() = if (featureFlagDataSource.getBoolean(FeatureFlag.USE_SUPABASE_SYNC)) {
             supabaseDataSource
         } else {
             firestoreDataSource

--- a/core/network/src/main/java/com/tgyuu/network/source/FeatureFlagDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/FeatureFlagDataSource.kt
@@ -1,26 +1,43 @@
 package com.tgyuu.network.source
 
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import com.tgyuu.domain.repository.FeatureFlag
 import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
+import javax.inject.Singleton
 
 @Singleton
 class FeatureFlagDataSource @Inject constructor(
     private val remoteConfig: FirebaseRemoteConfig,
 ) {
     init {
+        remoteConfig.setConfigSettingsAsync(
+            FirebaseRemoteConfigSettings.Builder()
+                .setMinimumFetchIntervalInSeconds(FETCH_INTERVAL_SECONDS)
+                .build()
+        )
         remoteConfig.setDefaultsAsync(
-            mapOf(USE_SUPABASE_SYNC to false)
+            mapOf(
+                FeatureFlag.USE_SUPABASE_SYNC to false,
+                FeatureFlag.USE_AUTO_BACKUP to false,
+            )
         )
         remoteConfig.fetchAndActivate()
     }
 
+    suspend fun fetchAndAwait() {
+        runCatching {
+            suspendCancellableCoroutine { cont ->
+                remoteConfig.fetchAndActivate().addOnCompleteListener { cont.resume(Unit) }
+            }
+        }
+    }
+
     fun getBoolean(key: String): Boolean = remoteConfig.getBoolean(key)
 
-    companion object Flag {
-        const val USE_SUPABASE_SYNC = "featureflag/sync_use_supabase"
+    private companion object {
+        const val FETCH_INTERVAL_SECONDS = 300L
     }
 }

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
@@ -70,6 +70,8 @@ import com.tgyuu.setting.graph.ui.bottomsheet.AlarmTimeBottomSheet
 import com.tgyuu.setting.graph.ui.bottomsheet.CalendarStartDayBottomSheet
 import com.tgyuu.setting.graph.ui.dialog.ConfirmClearDialog
 import kotlinx.coroutines.launch
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 private val SettingItemVerticalPadding = 16.dp
 private val SettingDividerBottomPadding = 16.dp
@@ -151,6 +153,7 @@ internal fun SettingRoute(
         onUpdateClick = { isImmediateUpdate ->
             viewModel.onIntent(SettingIntent.OnUpdateClick(isImmediateUpdate))
         },
+        onAutoBackupToggleClick = { viewModel.onIntent(SettingIntent.OnAutoBackupToggleClick) },
     )
 }
 
@@ -172,6 +175,7 @@ private fun SettingScreen(
     onStartDayClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
+    onAutoBackupToggleClick: () -> Unit,
 ) {
     var isShowClearConfirm by remember { mutableStateOf(false) }
     if (isShowClearConfirm) {
@@ -203,6 +207,7 @@ private fun SettingScreen(
             onStartDayClick = onStartDayClick,
             onInAppReviewClick = onInAppReviewClick,
             onUpdateClick = onUpdateClick,
+            onAutoBackupToggleClick = onAutoBackupToggleClick,
         )
     } else {
         TabletSettingScreen(
@@ -222,6 +227,7 @@ private fun SettingScreen(
             onStartDayClick = onStartDayClick,
             onInAppReviewClick = onInAppReviewClick,
             onUpdateClick = onUpdateClick,
+            onAutoBackupToggleClick = onAutoBackupToggleClick,
         )
     }
 }
@@ -244,6 +250,7 @@ private fun PhoneSettingScreen(
     onStartDayClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
+    onAutoBackupToggleClick: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         EbbingMainTopBar(
@@ -282,8 +289,12 @@ private fun PhoneSettingScreen(
             )
 
             DataBody(
+                autoBackupFeatureEnabled = state.autoBackupFeatureEnabled,
+                autoBackupEnabled = state.autoBackupEnabled,
+                lastSyncTime = state.lastSyncTime?.let { formatSyncTime(it) },
                 onSyncClick = onSyncClick,
                 onClearClick = onClearClick,
+                onAutoBackupToggleClick = onAutoBackupToggleClick,
             )
 
             ThemeBody(
@@ -331,6 +342,7 @@ private fun TabletSettingScreen(
     onStartDayClick: () -> Unit,
     onInAppReviewClick: () -> Unit,
     onUpdateClick: (isImmediateUpdate: Boolean) -> Unit,
+    onAutoBackupToggleClick: () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         EbbingMainTopBar(
@@ -368,8 +380,12 @@ private fun TabletSettingScreen(
                 )
 
                 DataBody(
+                    autoBackupFeatureEnabled = state.autoBackupFeatureEnabled,
+                    autoBackupEnabled = state.autoBackupEnabled,
+                    lastSyncTime = state.lastSyncTime?.let { formatSyncTime(it) },
                     onSyncClick = onSyncClick,
                     onClearClick = onClearClick,
+                    onAutoBackupToggleClick = onAutoBackupToggleClick,
                 )
             }
 
@@ -643,8 +659,12 @@ private fun TagRepeatCycleBody(
 
 @Composable
 private fun DataBody(
+    autoBackupFeatureEnabled: Boolean,
+    autoBackupEnabled: Boolean,
+    lastSyncTime: String?,
     onSyncClick: () -> Unit,
     onClearClick: () -> Unit,
+    onAutoBackupToggleClick: () -> Unit,
 ) {
     Text(
         text = "데이터",
@@ -672,6 +692,40 @@ private fun DataBody(
             contentDescription = "상세 내용",
             modifier = Modifier.padding(start = 4.dp),
         )
+    }
+
+    if (autoBackupFeatureEnabled) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = SettingItemVerticalPadding),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = stringResource(R.string.setting_auto_backup),
+                    style = EbbingTheme.typography.heading16SB,
+                    color = EbbingTheme.colors.textOnBackground,
+                    modifier = Modifier.weight(1f),
+                )
+
+                EbbingToggle(
+                    checked = autoBackupEnabled,
+                    onCheckedChange = { onAutoBackupToggleClick() },
+                )
+            }
+
+            if (lastSyncTime != null) {
+                Text(
+                    text = stringResource(R.string.setting_last_sync_time, lastSyncTime),
+                    style = EbbingTheme.typography.body14M,
+                    color = EbbingTheme.colors.textSub,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
     }
 
     Row(
@@ -1057,6 +1111,13 @@ private fun PreviewSettingScreen() {
             onStartDayClick = {},
             onInAppReviewClick = {},
             onUpdateClick = {},
+            onAutoBackupToggleClick = {},
         )
     }
 }
+
+private val syncTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")
+
+private fun formatSyncTime(time: ZonedDateTime): String =
+    time.toLocalDateTime().format(syncTimeFormatter)

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
@@ -11,6 +11,9 @@ import com.tgyuu.common.event.EventBus
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.ConfigRepository.Companion.DEFAULT_ALARM_MESSAGE
+import com.tgyuu.domain.repository.FeatureFlag
+import com.tgyuu.domain.repository.FeatureFlagRepository
+import com.tgyuu.domain.repository.SyncRepository
 import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.inappreview.InAppReviewManager
 import com.tgyuu.inappupdate.InAppUpdateManager
@@ -37,11 +40,13 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingViewModel @Inject constructor(
     private val configRepository: ConfigRepository,
+    private val syncRepository: SyncRepository,
     private val todoRepository: TodoRepository,
     private val alarmScheduler: AlarmScheduler,
     private val navigationBus: NavigationBus,
     private val eventBus: EventBus,
     private val analyticsHelper: AnalyticsHelper,
+    private val featureFlagRepository: FeatureFlagRepository,
     val inAppReviewManager: InAppReviewManager,
     val inAppUpdateManager: InAppUpdateManager,
 ) : BaseViewModel<SettingState, SettingIntent>(SettingState()) {
@@ -83,6 +88,22 @@ class SettingViewModel @Inject constructor(
                     .collect { setState { copy(mondayStart = it) } }
             }
 
+            launch {
+                featureFlagRepository.fetchAndAwait()
+                val featureEnabled = featureFlagRepository.getBoolean(FeatureFlag.USE_AUTO_BACKUP)
+                setState { copy(autoBackupFeatureEnabled = featureEnabled) }
+
+                if (featureEnabled) {
+                    configRepository.getAutoBackupEnabled()
+                        .collect { setState { copy(autoBackupEnabled = it) } }
+                }
+            }
+
+            launch {
+                val lastSyncTime = syncRepository.getLocalSyncedAt()
+                setState { copy(lastSyncTime = lastSyncTime) }
+            }
+
             configRepository.getNotificationEnabled()
                 .collect { setState { copy(notificationEnabled = it) } }
         }
@@ -110,6 +131,7 @@ class SettingViewModel @Inject constructor(
             is SettingIntent.OnUpdateClick -> onUpdateClick(intent.isImmediateUpdate)
             is SettingIntent.OnStartDayClick -> onStartDayClick(intent.content)
             is SettingIntent.OnUpdateStartDay -> onUpdateStartDay(intent.mondayStart)
+            SettingIntent.OnAutoBackupToggleClick -> onAutoBackupToggleClick()
         }
     }
 
@@ -240,6 +262,13 @@ class SettingViewModel @Inject constructor(
             AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "StartDay")
         )
         eventBus.sendEvent(EbbingEvent.ShowBottomSheet(content))
+    }
+
+    private suspend fun onAutoBackupToggleClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "AutoBackup_Toggle")
+        )
+        configRepository.setAutoBackupEnabled(!currentState.autoBackupEnabled)
     }
 
     private suspend fun onUpdateStartDay(mondayStart: Boolean) {

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
@@ -24,4 +24,5 @@ sealed interface SettingIntent : UiIntent {
     data class OnUpdateClick(val isImmediateUpdate: Boolean) : SettingIntent
     data class OnStartDayClick(val content: BottomSheetContent) : SettingIntent
     data class OnUpdateStartDay(val mondayStart: Boolean) : SettingIntent
+    data object OnAutoBackupToggleClick : SettingIntent
 }

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingState.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingState.kt
@@ -3,6 +3,7 @@ package com.tgyuu.setting.graph.main.contract
 import com.tgyuu.common.base.UiState
 import com.tgyuu.domain.model.UpdateInfo
 import com.tgyuu.domain.repository.ConfigRepository.Companion.DEFAULT_ALARM_MESSAGE
+import java.time.ZonedDateTime
 
 data class SettingState(
     val updateInfo: UpdateInfo? = null,
@@ -13,6 +14,9 @@ data class SettingState(
     val alarmMessage: String = DEFAULT_ALARM_MESSAGE,
     val alarmMessageBottomSheet: AlarmMessageBottomSheetState = AlarmMessageBottomSheetState(),
     val mondayStart: Boolean = false,
+    val autoBackupFeatureEnabled: Boolean = false,
+    val autoBackupEnabled: Boolean = false,
+    val lastSyncTime: ZonedDateTime? = null,
 ) : UiState
 
 data class AlarmMessageBottomSheetState(


### PR DESCRIPTION
## Summary
- 앱이 백그라운드로 전환될 때(onStop) 네트워크가 연결되어 있으면 자동으로 `syncUpData()` 실행
- 네트워크 미연결 시 `backupPending` 플래그를 저장하고, 네트워크 복구 시 자동 sync
- 설정 화면 데이터 섹션에 "자동 백업" on/off 토글 추가 (기본값: off)
- 10초 쿨타임(`SYNC_UP_COOL_TIME`) 존중하여 중복 sync 방지
- 기존 `DelegatingSyncDataSource`의 `getBooleanSync` → `getBoolean` 오타 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 설정에 자동 백업 토글 추가 - 사용자가 자동 백업 기능을 활성화/비활성화할 수 있습니다.
* 네트워크 기반 자동 백업 - 앱이 종료될 때 또는 네트워크 연결 시 자동으로 데이터를 백업합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->