### PR TITLE
feat: 재부팅/앱 시작 시 알람 자동 재등록으로 알림 누락 방지

### DIFF
--- a/core/alarm/src/main/AndroidManifest.xml
+++ b/core/alarm/src/main/AndroidManifest.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application>
         <receiver
             android:name=".TodoAlarmReceiver"
             android:exported="false" />
+
+        <receiver
+            android:name=".BootCompletedReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/core/alarm/src/main/java/com/tgyuu/alarm/AlarmInitializer.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/AlarmInitializer.kt
@@ -1,0 +1,20 @@
+package com.tgyuu.alarm
+
+import com.tgyuu.common.initializer.Initializer
+import com.tgyuu.common.initializer.Initializer.Companion.PRIORITY_LOW
+import javax.inject.Inject
+
+/**
+ * 앱 시작 시 저장된 미래 일정들의 알람을 재등록한다.
+ * 절전/강제종료 등으로 알람이 취소된 경우를 대비한 복구 로직.
+ */
+class AlarmInitializer @Inject constructor(
+    private val alarmRescheduler: AlarmRescheduler,
+) : Initializer {
+    override val priority: Int
+        get() = PRIORITY_LOW
+
+    override suspend fun initialize() {
+        alarmRescheduler.rescheduleAll()
+    }
+}

--- a/core/alarm/src/main/java/com/tgyuu/alarm/AlarmRescheduler.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/AlarmRescheduler.kt
@@ -1,0 +1,58 @@
+package com.tgyuu.alarm
+
+import android.util.Log
+import com.tgyuu.domain.repository.ConfigRepository
+import com.tgyuu.domain.repository.TodoRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 저장된 미래 일정들의 알람을 일괄 재등록한다.
+ * 재부팅(BootCompletedReceiver) / 앱 시작(AlarmInitializer) 시점에 호출되어,
+ * 시스템이 알람을 비운 경우(재부팅, 절전, 강제종료 등)에도 알림이 누락되지 않도록 한다.
+ */
+@Singleton
+class AlarmRescheduler @Inject constructor(
+    private val alarmScheduler: AlarmScheduler,
+    private val todoRepository: TodoRepository,
+    private val configRepository: ConfigRepository,
+) {
+    suspend fun rescheduleAll() = withContext(Dispatchers.IO) {
+        val notificationEnabled =
+            configRepository.getNotificationEnabled().firstOrNull() ?: true
+        if (!notificationEnabled) return@withContext
+
+        // 정확 알람 권한이 없으면 재등록을 시도하지 않는다.
+        // (권한 없을 때 scheduleDailyExact 가 설정 화면을 띄우므로 반복 호출을 방지)
+        if (!alarmScheduler.canScheduleExact()) return@withContext
+
+        val (hour, minute) = configRepository.getAlarmTime()
+        val now = System.currentTimeMillis()
+
+        todoRepository.loadUpcomingSchedules(LocalDate.now())
+            .map { it.date }
+            .distinct()
+            .forEach { date ->
+                runCatching {
+                    val triggerAtMillis = date.atTime(hour, minute)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli()
+
+                    if (triggerAtMillis <= now) return@forEach
+
+                    alarmScheduler.scheduleDailyExact(
+                        date = date,
+                        triggerAtMillis = triggerAtMillis,
+                    )
+                }.onFailure {
+                    Log.e("AlarmRescheduler", "알람 재등록 실패: $date", it)
+                }
+            }
+    }
+}

--- a/core/alarm/src/main/java/com/tgyuu/alarm/AlarmScheduler.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/AlarmScheduler.kt
@@ -55,6 +55,9 @@ class AlarmScheduler @Inject constructor(
         alarmManager.cancel(buildPendingIntent(date))
     }
 
+    fun canScheduleExact(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()
+
     private fun buildPendingIntent(date: LocalDate): PendingIntent =
         Intent(context, TodoAlarmReceiver::class.java).apply {
             putExtra("date", date.toString())

--- a/core/alarm/src/main/java/com/tgyuu/alarm/BootCompletedReceiver.kt
+++ b/core/alarm/src/main/java/com/tgyuu/alarm/BootCompletedReceiver.kt
@@ -1,0 +1,53 @@
+package com.tgyuu.alarm
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * 재부팅 시 AlarmManager 에 등록된 알람이 모두 사라지므로,
+ * BOOT_COMPLETED 수신 시 저장된 미래 일정들의 알람을 재등록한다.
+ * 앱 업데이트(MY_PACKAGE_REPLACED) 시에도 동일하게 재등록한다.
+ */
+@AndroidEntryPoint
+class BootCompletedReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var alarmRescheduler: AlarmRescheduler
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED,
+            ACTION_QUICKBOOT_POWERON,
+            Intent.ACTION_MY_PACKAGE_REPLACED -> Unit
+
+            else -> return
+        }
+
+        val pendingResult = goAsync()
+        scope.launch {
+            try {
+                alarmRescheduler.rescheduleAll()
+            } catch (e: Exception) {
+                Log.e("BootCompletedReceiver", "부팅 후 알람 재등록 실패", e)
+            } finally {
+                pendingResult.finish()
+                scope.cancel()
+            }
+        }
+    }
+
+    private companion object {
+        // 일부 제조사(삼성 등)에서 사용하는 빠른 부팅 액션
+        const val ACTION_QUICKBOOT_POWERON = "android.intent.action.QUICKBOOT_POWERON"
+    }
+}

--- a/core/alarm/src/main/java/com/tgyuu/di/AlarmModule.kt
+++ b/core/alarm/src/main/java/com/tgyuu/di/AlarmModule.kt
@@ -2,11 +2,15 @@ package com.tgyuu.di
 
 import android.app.AlarmManager
 import android.content.Context
+import com.tgyuu.alarm.AlarmInitializer
+import com.tgyuu.common.initializer.Initializer
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import javax.inject.Singleton
 
 @Module
@@ -18,4 +22,15 @@ object AlarmModule {
     fun provideAlarmManager(
         @ApplicationContext context: Context
     ): AlarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AlarmBindsModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindAlarmInitializer(
+        impl: AlarmInitializer,
+    ): Initializer
 }


### PR DESCRIPTION
## 배경
스케줄 알림이 "올 때도 있고 안 올 때도 있다"는 문의(갤럭시 S22+)를 검토한 결과, 두 가지 원인을 확인했습니다.

1. **재부팅 시 알람 전부 소실** — 안드로이드는 재부팅 시 AlarmManager 알람을 모두 삭제하는데, 이를 재등록하는 로직이 없었음 (BOOT_COMPLETED 리시버 부재)
2. **절전/강제종료로 알람 취소** — 앱이 절전되거나 강제종료되면 알람이 취소될 수 있으나, 복구 로직이 없었음

## 변경 사항
- **BootCompletedReceiver** 추가: `BOOT_COMPLETED` / `QUICKBOOT_POWERON`(삼성) / `MY_PACKAGE_REPLACED`(앱 업데이트) 수신 시 알람 재등록
- **AlarmInitializer** 추가: 기존 `Initializer` 패턴으로 앱 시작 시 알람 재검증/재등록
- **AlarmRescheduler**: 미래 일정(`loadUpcomingSchedules`)을 날짜별로 묶어 알람 일괄 재등록하는 공통 로직
  - 알림 비활성 시 / 정확 알람 권한 없을 시 조기 종료 (설정 화면 반복 노출 방지)
- `RECEIVE_BOOT_COMPLETED` 권한 및 부팅 리시버 매니페스트 등록
- `AlarmScheduler.canScheduleExact()` 헬퍼 추가

## 참고
- 삼성 One UI의 공격적 배터리 최적화는 이번 변경으로 완화되지만 근본 해결은 아닙니다. 추후 배터리 최적화 예외 요청/안내(별도 작업)가 필요합니다.
- 현재 develop은 \`DelegatingSyncDataSource\`의 \`getBooleanSync\` 미존재 참조로 컴파일이 깨져 있습니다(PR #94 영향). PR #96에 동일 수정이 포함되어 있어, #96 머지 후 develop이 정상화됩니다. 본 PR에는 해당 수정을 포함하지 않았습니다(관심사 분리).

## Test plan
- [ ] 일정 등록 후 기기 재부팅 → 알림 정상 수신 확인
- [ ] 앱 강제종료 후 재실행 → 알람 재등록 확인
- [ ] 알림 비활성 상태에서 재부팅 → 알림 미발생 확인
- [ ] 정확 알람 권한 미허용 시 설정 화면 반복 노출 없는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기기 재부팅 및 앱 업데이트 후 예약된 알람이 자동으로 복구됩니다.
  * 저장된 알람들이 설정된 시간에 정상적으로 울리도록 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->