### PR TITLE
fix: 일정 모아보기 바텀시트 옵션 정렬을 홈 화면과 통일

### DIFF
--- a/feature/schedule/src/main/java/com/tgyuu/dashboard/ui/bottomsheet/ScheduleOptionsBottomSheet.kt
+++ b/feature/schedule/src/main/java/com/tgyuu/dashboard/ui/bottomsheet/ScheduleOptionsBottomSheet.kt
@@ -349,7 +349,7 @@ private fun BottomSheetOptionItem(
     onClick: () -> Unit,
 ) {
     Box(
-        contentAlignment = Alignment.CenterStart,
+        contentAlignment = Alignment.TopStart,
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() }


### PR DESCRIPTION
## 배경
홈 화면과 일정 모아보기 화면의 옵션 바텀시트가 동일한 항목 구조임에도 옵션 텍스트의 세로 정렬이 달라 패딩이 다르게 보이는 문제가 있었습니다.

- **홈** (`OptionsBottomSheet` 등): `Text` + `.height(62.dp)` → 텍스트 **상단 정렬**
- **모아보기** (`ScheduleOptionsBottomSheet`의 `BottomSheetOptionItem`): `Box(contentAlignment = CenterStart).height(62.dp)` → 텍스트 **세로 중앙 정렬**

## 변경 사항
- 모아보기의 공통 옵션 항목(`BottomSheetOptionItem`) 정렬을 `CenterStart` → `TopStart` 로 변경하여 홈 화면과 동일하게 통일
- 이 헬퍼를 공유하는 모아보기의 모든 옵션 바텀시트(편집/수정/삭제/미루기)에 일괄 적용됨

## Test plan
- [ ] 모아보기 화면에서 일정 옵션 바텀시트를 열어 항목 간격이 홈 화면과 동일한지 확인
- [ ] 수정/삭제/미루기 바텀시트도 동일하게 정렬되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 옵션 목록의 정렬 위치가 상단 기준으로 조정되어 사용자 인터페이스의 시각적 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->