### PR TITLE
feat: 연동 해제를 X 아이콘 클릭으로 변경

### DIFF
--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
@@ -4,12 +4,9 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +32,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -381,7 +379,6 @@ private fun SectionDivider() {
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ConnectedDeviceSection(
     state: SyncMainState,
@@ -399,12 +396,6 @@ private fun ConnectedDeviceSection(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .combinedClickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = {},
-                onLongClick = onDisconnectClick,
-            )
             .padding(vertical = 12.dp),
     ) {
         Box(
@@ -432,6 +423,17 @@ private fun ConnectedDeviceSection(
             text = state.connectedDeviceUuidPrefix,
             style = EbbingTheme.typography.body14M,
             color = EbbingTheme.colors.textDisabled,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(R.drawable.ic_close),
+            contentDescription = "연동 해제",
+            colorFilter = ColorFilter.tint(EbbingTheme.colors.textSub),
+            modifier = Modifier
+                .size(24.dp)
+                .clickable { onDisconnectClick() },
         )
     }
 


### PR DESCRIPTION
## Summary
- 연동된 기기 해제 방식을 **롱클릭 → 연결된 기기 우측 X 아이콘 클릭**으로 변경
- X 클릭 시 기존 연동 해제 Alert(`ConfirmDisconnectDialog`) 표시
- `ConnectedDeviceSection`의 `combinedClickable`/`onLongClick` 제거, 우측에 `ic_close` 아이콘 추가 (`Spacer(weight)`로 우측 정렬)

## Base
`feature/device-info-display` (PR #96) 위에 스택된 브랜치

## Test
- 에뮬레이터(Pixel_8_Pro)에서 연결 상태 화면 X 아이콘 노출 및 클릭 시 해제 Alert 표시 확인
- `:feature:sync` 컴파일 통과