### PR TITLE
feat: 동기화 화면 첫 진입 로딩 스피너 추가

### DIFF
--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
@@ -208,6 +208,15 @@ internal fun SyncMainScreen(
                     .weight(1f)
                     .padding(horizontal = 20.dp),
             )
+        } else if (state.isInitialLoading) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) {
+                CircularProgressIndicator(color = EbbingTheme.colors.primaryNormal)
+            }
         } else {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 if (state.linkedUuid != null) {

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
@@ -153,6 +153,8 @@ class SyncMainViewModel @Inject constructor(
         localLastSyncedAtJob.join()
         connectInfoJob.join()
         disconnectWatchJob.join()
+
+        setState { copy(isInitialLoading = false) }
     }
 
     override suspend fun processIntent(intent: SyncIntent) {

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/contract/SyncMainState.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/contract/SyncMainState.kt
@@ -13,6 +13,7 @@ data class SyncMainState(
     val localLastSyncedAt: ZonedDateTime? = null,
     val serverLastUpdatedAt: ZonedDateTime? = null,
     val isNetworkLoading: Boolean = true,
+    val isInitialLoading: Boolean = true,
     val isSyncUpEnabled: Boolean = true,
     // QR 연동
     val connectCode: String = "",


### PR DESCRIPTION
## Summary
- "다른 기기에서도 사용하기" 화면 첫 진입 시 로딩 동안 **스피너(CircularProgressIndicator)** 표시
- 로딩 완료 후 실제 콘텐츠(연결됨/미연결)로 전환

## Changes
- `SyncMainState`: 첫 진입 전용 `isInitialLoading` 플래그 추가 (`isNetworkLoading`과 분리 — 재로드/동기화 시엔 미표시)
- `SyncMainViewModel.loadInitData`: 초기 로드 완료 후 `isInitialLoading = false`
- `SyncMainScreen`: 초기 로딩 시 중앙 정렬 스피너 표시

## Test
- `:feature:sync` 컴파일 통과