### PR TITLE
feat: 동기화 쿨타임 디바이스 기준 변경 및 수동 동기화 안내 추가

### DIFF
--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
@@ -483,6 +483,13 @@ private fun LastSyncSection(
             contentDescription = null,
         )
     }
+
+    Text(
+        text = "자동으로 동기화되지 않아요. 눌러서 직접 동기화해 주세요.",
+        style = EbbingTheme.typography.caption12R,
+        color = EbbingTheme.colors.textSub,
+        modifier = Modifier.padding(top = 8.dp),
+    )
 }
 
 @Composable

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
@@ -90,15 +90,21 @@ class SyncMainViewModel @Inject constructor(
             setState { copy(localLastSyncedAt = lastSyncedAt) }
         }
 
+        // 동기화 쿨타임은 서버가 아니라 이 디바이스의 마지막 동기화 기준 10초
+        val syncUpEnabledJob = launch {
+            val localSyncedAt = syncRepository.getLocalSyncedAt()
+            val isSyncUpEnabled = localSyncedAt == null ||
+                    Duration.between(localSyncedAt, ZonedDateTime.now())
+                        .toMillis() >= SYNC_UP_COOL_TIME
+            setState { copy(isSyncUpEnabled = isSyncUpEnabled) }
+        }
+
         val serverLastUpdatedAtJob = launch {
             val connectedUuid = syncRepository.getConnectedUuid()
             suspendRunCatching {
                 syncRepository.getServerLastUpdatedAt()
             }.onSuccess { serverSyncInfo ->
                 val serverLastUpdatedAt = serverSyncInfo?.lastUpdatedAt
-                val isSyncUpEnabled = serverLastUpdatedAt == null ||
-                        Duration.between(serverLastUpdatedAt, ZonedDateTime.now())
-                            .toMillis() >= SYNC_UP_COOL_TIME
                 val connectedDeviceName = if (connectedUuid != null) {
                     serverSyncInfo?.connectedDeviceName
                 } else {
@@ -108,7 +114,6 @@ class SyncMainViewModel @Inject constructor(
                     copy(
                         serverLastUpdatedAt = serverLastUpdatedAt,
                         connectedDeviceName = connectedDeviceName,
-                        isSyncUpEnabled = isSyncUpEnabled,
                         localLastSyncedAt = if (isConnected) serverLastUpdatedAt else localLastSyncedAt,
                     )
                 }
@@ -149,8 +154,9 @@ class SyncMainViewModel @Inject constructor(
         uuidJob.join()
         deviceNameJob.join()
         linkedUuidJob.join()
-        serverLastUpdatedAtJob.join()
         localLastSyncedAtJob.join()
+        syncUpEnabledJob.join()
+        serverLastUpdatedAtJob.join()
         connectInfoJob.join()
         disconnectWatchJob.join()
 


### PR DESCRIPTION
## Summary
- **동기화 쿨타임을 디바이스(로컬) 기준으로 변경**: 기존엔 서버 마지막 갱신 시각 기준이라 다른 기기가 방금 동기화하면 내 버튼도 막혔음 → 이제 **이 디바이스의 마지막 동기화 기준 10초**로만 막힘 (네트워크 무관, 오프라인에서도 동작)
- **수동 동기화 안내 문구 추가**: 자동 동기화로 오해하지 않도록 마지막 동기화 섹션에 안내 추가

## Changes
- `SyncMainViewModel.loadInitData`: `isSyncUpEnabled`를 `getLocalSyncedAt()` 기준으로 계산하는 `syncUpEnabledJob` 분리 (서버 호출과 분리)
- `SyncMainScreen` `LastSyncSection`: "자동으로 동기화되지 않아요. 눌러서 직접 동기화해 주세요." 캡션 추가

## Test
- `:feature:sync` 컴파일 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 동기화 화면에 안내 문구 추가 - "자동으로 동기화되지 않아요. 눌러서 직접 동기화해 주세요." 메시지 표시

* **개선사항**
  * 동기화 활성화 판단 로직 개선 - 로컬 동기화 시점 기반의 더 정확한 상태 관리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->