### PR TITLE
fix: QR 스캔 화면 시스템 뒤로가기 처리

### DIFF
--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -187,6 +188,10 @@ internal fun SyncMainScreen(
                 isShowDisconnectDialog = false
             },
         )
+    }
+
+    BackHandler(enabled = state.isScanning) {
+        onDismissScan()
     }
 
     Column(


### PR DESCRIPTION
## Problem
QR 스캔 카메라 화면에서 시스템 뒤로가기를 누르면 스캔만 닫히는 게 아니라 동기화 화면 자체를 빠져나갔음 (`isScanning`은 별도 라우트가 아닌 상태라 시스템 뒤로가기가 미처리되어 nav가 pop됨).

## Fix
- `SyncMainScreen`에 `BackHandler(enabled = state.isScanning) { onDismissScan() }` 추가
- 스캔 중 시스템 뒤로가기 → 카메라만 닫고 동기화 화면으로 복귀 (상단바 뒤로가기와 동일 동작)

## Test
- `:feature:sync` 컴파일 통과