### PR TITLE
fix: 네트워크 배너 시스템 바 겹침 수정

### DIFF
--- a/feature/sync/src/main/java/com/tgyuu/sync/network/NetworkBanner.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/network/NetworkBanner.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,6 +55,7 @@ fun NetworkBanner(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .navigationBarsPadding()
                     .height(60.dp)
                     .background(EbbingTheme.colors.statusError)
                     .padding(horizontal = 20.dp),
@@ -87,6 +89,7 @@ fun NetworkBanner(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .navigationBarsPadding()
                     .height(60.dp)
                     .background(EbbingTheme.colors.statusSuccess)
                     .padding(horizontal = 20.dp),


### PR DESCRIPTION
## Problem
edge-to-edge 환경에서 네트워크 미연결 하단 배너가 시스템 내비게이션 바와 겹쳐 그려졌음.

## Fix
- `NetworkBanner`의 배너 Row(에러/연결됨)에 `navigationBarsPadding()` 적용 → 배너가 시스템 바 위로 올라감.

## Test
- `:feature:sync` 컴파일 통과