### PR TITLE
feat: QR 연동 실패 시 네트워크 오류 분기 처리

### DIFF
--- a/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
@@ -2,5 +2,4 @@ package com.tgyuu.common
 
 import java.io.IOException
 
-fun Throwable.isNetworkError(): Boolean =
-    generateSequence(this) { it.cause }.any { it is IOException }
+fun Throwable.isNetworkError(): Boolean = this is IOException

--- a/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
@@ -1,0 +1,23 @@
+package com.tgyuu.common
+
+import java.io.IOException
+
+/**
+ * 네트워크 연결/통신 오류 여부를 판단한다.
+ *
+ * 예외의 cause 체인을 따라가며 [IOException] 계열인지 확인한다.
+ * Ktor/Supabase 의 소켓·타임아웃·호스트 관련 예외들은 모두 [IOException] 을 상속하므로 이를 기준으로 판별한다.
+ */
+fun Throwable.isNetworkError(): Boolean {
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_CAUSE_DEPTH) {
+        if (current is IOException) return true
+        if (current == current.cause) break
+        current = current.cause
+        depth++
+    }
+    return false
+}
+
+private const val MAX_CAUSE_DEPTH = 10

--- a/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
@@ -2,22 +2,5 @@ package com.tgyuu.common
 
 import java.io.IOException
 
-/**
- * 네트워크 연결/통신 오류 여부를 판단한다.
- *
- * 예외의 cause 체인을 따라가며 [IOException] 계열인지 확인한다.
- * Ktor/Supabase 의 소켓·타임아웃·호스트 관련 예외들은 모두 [IOException] 을 상속하므로 이를 기준으로 판별한다.
- */
-fun Throwable.isNetworkError(): Boolean {
-    var current: Throwable? = this
-    var depth = 0
-    while (current != null && depth < MAX_CAUSE_DEPTH) {
-        if (current is IOException) return true
-        if (current == current.cause) break
-        current = current.cause
-        depth++
-    }
-    return false
-}
-
-private const val MAX_CAUSE_DEPTH = 10
+fun Throwable.isNetworkError(): Boolean =
+    generateSequence(this) { it.cause }.any { it is IOException }

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
@@ -8,6 +8,7 @@ import com.tgyuu.common.event.BottomSheetContent
 import com.tgyuu.common.event.EbbingEvent
 import com.tgyuu.common.event.EbbingEvent.ShowBottomSheet
 import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.isNetworkError
 import com.tgyuu.common.suspendRunCatching
 import com.tgyuu.domain.model.ErrorBus
 import com.tgyuu.domain.model.Timer
@@ -372,7 +373,12 @@ class SyncMainViewModel @Inject constructor(
         }.onFailure { error ->
             setState { copy(isScanLoading = false) }
             errorBus.sendError(error)
-            eventBus.sendEvent(EbbingEvent.ShowSnackBar("연동에 실패했습니다. 다시 시도해 주세요."))
+            val message = if (error.isNetworkError()) {
+                "네트워크 연결을 확인해 주세요."
+            } else {
+                "연동에 실패했습니다. 다시 시도해 주세요."
+            }
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(message))
             isProcessing.set(false)
         }
     }

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/main/SyncMainViewModel.kt
@@ -259,7 +259,12 @@ class SyncMainViewModel @Inject constructor(
             }
         }.onFailure { error ->
             errorBus.sendError(error)
-            eventBus.sendEvent(EbbingEvent.ShowSnackBar(error.message ?: "동기화에 실패하였습니다."))
+            val message = if (error.isNetworkError()) {
+                "네트워크 연결을 확인해 주세요."
+            } else {
+                error.message ?: "동기화에 실패하였습니다."
+            }
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(message))
         }.also {
             setState { copy(isNetworkLoading = false) }
         }
@@ -288,7 +293,12 @@ class SyncMainViewModel @Inject constructor(
             eventBus.sendEvent(EbbingEvent.ShowSnackBar("연동 해제에 성공하였습니다."))
         }.onFailure { error ->
             errorBus.sendError(error)
-            eventBus.sendEvent(EbbingEvent.ShowSnackBar("연동 해제에 실패하였습니다."))
+            val message = if (error.isNetworkError()) {
+                "네트워크 연결을 확인해 주세요."
+            } else {
+                "연동 해제에 실패하였습니다."
+            }
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(message))
         }.also {
             setState { copy(isNetworkLoading = false) }
         }
@@ -322,7 +332,12 @@ class SyncMainViewModel @Inject constructor(
             eventBus.sendEvent(ShowBottomSheet(content))
         }.onFailure { error ->
             errorBus.sendError(error)
-            eventBus.sendEvent(EbbingEvent.ShowSnackBar("QR 코드 생성에 실패했습니다. 네트워크를 확인해 주세요."))
+            val message = if (error.isNetworkError()) {
+                "네트워크 연결을 확인해 주세요."
+            } else {
+                "QR 코드 생성에 실패했습니다. 다시 시도해 주세요."
+            }
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(message))
         }
     }
 


### PR DESCRIPTION
## Summary
- QR 스캔 연동(`handleQrDetected`) 실패 시, 네트워크 오류와 그 외 오류를 구분해 다른 안내 문구 표시
  - 네트워크 오류: "네트워크 연결을 확인해 주세요."
  - 그 외: "연동에 실패했습니다. 다시 시도해 주세요." (기존)

## Changes
- `core/common` `Throwable.isNetworkError()` 유틸 추가: 예외 cause 체인을 따라가며 `IOException` 계열인지 판별 (Ktor/Supabase 네트워크 예외는 IOException 상속)
- `SyncMainViewModel.handleQrDetected` onFailure에서 `isNetworkError()`로 분기

## Note
유틸은 다른 동기화 흐름(생성/동기화/해제)에도 재사용 가능합니다.

## Test
- `:core:common`, `:feature:sync` 컴파일 통과