### PR TITLE
feat: 태그/반복 주기 관리 화면에 추가 버튼과 Empty UI 추가

### DIFF
--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/RepeatCycleScreen.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/RepeatCycleScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,6 +44,7 @@ import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetListItemDef
 import com.tgyuu.designsystem.component.EbbingOutlinedButton
 import com.tgyuu.designsystem.component.EbbingSolidButton
 import com.tgyuu.designsystem.component.EbbingSubTopBar
+import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.RepeatCycleUiModel
 import com.tgyuu.repeatcycle.graph.main.contract.RepeatCycleIntent
 import com.tgyuu.repeatcycle.graph.main.contract.RepeatCycleState
@@ -61,6 +64,7 @@ internal fun RepeatCycleRoute(
     RepeatCycleScreen(
         state = state,
         onBackClick = { viewModel.onIntent(RepeatCycleIntent.OnBackClick) },
+        onAddClick = { viewModel.onIntent(RepeatCycleIntent.OnAddClick) },
         onEditClick = { viewModel.onIntent(RepeatCycleIntent.OnEditClick(it)) },
         onDeleteClick = { viewModel.onIntent(RepeatCycleIntent.OnDeleteClick(it)) },
     )
@@ -70,6 +74,7 @@ internal fun RepeatCycleRoute(
 private fun RepeatCycleScreen(
     state: RepeatCycleState,
     onBackClick: () -> Unit,
+    onAddClick: () -> Unit,
     onEditClick: (RepeatCycleUiModel) -> Unit,
     onDeleteClick: (RepeatCycleUiModel) -> Unit,
     modifier: Modifier = Modifier,
@@ -100,9 +105,33 @@ private fun RepeatCycleScreen(
             EbbingSubTopBar(
                 title = "반복 주기 관리",
                 onNavigationClick = onBackClick,
+                rightComponent = {
+                    Text(
+                        text = "추가",
+                        style = EbbingTheme.typography.body16M,
+                        color = EbbingTheme.colors.primaryNormal,
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .clickable { onAddClick() },
+                    )
+                },
                 modifier = Modifier.padding(horizontal = 20.dp),
             )
-            if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT) {
+            if (state.repeatCycleList.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "등록된 반복 주기가 없어요.\n우측 상단 + 버튼을 눌러 반복 주기를 추가해보세요.",
+                        style = EbbingTheme.typography.body14M,
+                        textAlign = TextAlign.Center,
+                        color = EbbingTheme.colors.textDisabled,
+                    )
+                }
+            } else if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT) {
                 LazyColumn(
                     state = listState,
                     contentPadding = PaddingValues(bottom = 100.dp),
@@ -191,6 +220,7 @@ private fun PreviewRepeatCycle() {
                 )
             ),
             onBackClick = {},
+            onAddClick = {},
             onEditClick = {},
             onDeleteClick = {},
         )

--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/RepeatCycleViewModel.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/RepeatCycleViewModel.kt
@@ -31,6 +31,7 @@ class RepeatCycleViewModel @Inject constructor(
     override suspend fun processIntent(intent: RepeatCycleIntent) {
         when (intent) {
             RepeatCycleIntent.OnBackClick -> onBackClick()
+            RepeatCycleIntent.OnAddClick -> onAddClick()
             is RepeatCycleIntent.OnDeleteClick -> onDeleteClick(intent.repeatCycle)
             is RepeatCycleIntent.OnEditClick -> onEditClick(intent.repeatCycle)
         }
@@ -41,6 +42,15 @@ class RepeatCycleViewModel @Inject constructor(
             AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "Back")
         )
         navigationBus.navigate(NavigationEvent.Up)
+    }
+
+    private suspend fun onAddClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "AddRepeatCycle")
+        )
+        navigationBus.navigate(
+            NavigationEvent.To(RepeatCycleGraph.AddRepeatCycleRoute)
+        )
     }
 
     private suspend fun onDeleteClick(repeatCycle: RepeatCycleUiModel) {

--- a/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/contract/RepeatCycleIntent.kt
+++ b/feature/repeatcycle/src/main/java/com/tgyuu/repeatcycle/graph/main/contract/RepeatCycleIntent.kt
@@ -5,6 +5,7 @@ import com.tgyuu.designsystem.model.RepeatCycleUiModel
 
 sealed class RepeatCycleIntent : UiIntent {
     data object OnBackClick : RepeatCycleIntent()
+    data object OnAddClick : RepeatCycleIntent()
     data class OnEditClick(val repeatCycle: RepeatCycleUiModel) : RepeatCycleIntent()
     data class OnDeleteClick(val repeatCycle: RepeatCycleUiModel) : RepeatCycleIntent()
 }

--- a/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagScreen.kt
+++ b/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,6 +44,7 @@ import com.tgyuu.designsystem.component.bottomsheet.EbbingBottomSheetListItemDef
 import com.tgyuu.designsystem.component.EbbingOutlinedButton
 import com.tgyuu.designsystem.component.EbbingSolidButton
 import com.tgyuu.designsystem.component.EbbingSubTopBar
+import com.tgyuu.designsystem.foundation.EbbingTheme
 import com.tgyuu.designsystem.model.TodoTagUiModel
 import com.tgyuu.tag.graph.main.contract.TagIntent
 import com.tgyuu.tag.graph.main.contract.TagState
@@ -62,6 +65,7 @@ internal fun TagRoute(
     TagScreen(
         state = state,
         onBackClick = { viewModel.onIntent(TagIntent.OnBackClick) },
+        onAddClick = { viewModel.onIntent(TagIntent.OnAddClick) },
         onEditClick = { viewModel.onIntent(TagIntent.OnEditClick(it)) },
         onDeleteClick = { viewModel.onIntent(TagIntent.OnDeleteClick(it)) },
     )
@@ -71,6 +75,7 @@ internal fun TagRoute(
 private fun TagScreen(
     state: TagState,
     onBackClick: () -> Unit,
+    onAddClick: () -> Unit,
     onEditClick: (TodoTagUiModel) -> Unit,
     onDeleteClick: (TodoTagUiModel) -> Unit,
     modifier: Modifier = Modifier,
@@ -102,9 +107,33 @@ private fun TagScreen(
             EbbingSubTopBar(
                 title = "태그 관리",
                 onNavigationClick = onBackClick,
+                rightComponent = {
+                    Text(
+                        text = "추가",
+                        style = EbbingTheme.typography.body16M,
+                        color = EbbingTheme.colors.primaryNormal,
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .clickable { onAddClick() },
+                    )
+                },
                 modifier = Modifier.padding(horizontal = 20.dp),
             )
-            if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT) {
+            if (state.tagList.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "등록된 태그가 없어요.\n우측 상단 + 버튼을 눌러 태그를 추가해보세요.",
+                        style = EbbingTheme.typography.body14M,
+                        textAlign = TextAlign.Center,
+                        color = EbbingTheme.colors.textDisabled,
+                    )
+                }
+            } else if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT) {
                 LazyColumn(
                     state = listState,
                     contentPadding = PaddingValues(bottom = 100.dp),
@@ -205,6 +234,7 @@ private fun PreviewTag() {
                 )
             ),
             onBackClick = {},
+            onAddClick = {},
             onEditClick = {},
             onDeleteClick = {},
         )

--- a/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagViewModel.kt
+++ b/feature/tag/src/main/java/com/tgyuu/tag/graph/main/TagViewModel.kt
@@ -31,6 +31,7 @@ class TagViewModel @Inject constructor(
     override suspend fun processIntent(intent: TagIntent) {
         when (intent) {
             TagIntent.OnBackClick -> onBackClick()
+            TagIntent.OnAddClick -> onAddClick()
             is TagIntent.OnDeleteClick -> onDeleteClick(intent.tag)
             is TagIntent.OnEditClick -> onEditClick(intent.tag)
         }
@@ -41,6 +42,15 @@ class TagViewModel @Inject constructor(
             AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "Back")
         )
         navigationBus.navigate(NavigationEvent.Up)
+    }
+
+    private suspend fun onAddClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "AddTag")
+        )
+        navigationBus.navigate(
+            NavigationEvent.To(TagGraph.AddTagRoute)
+        )
     }
 
     private suspend fun onDeleteClick(tag: TodoTagUiModel) {

--- a/feature/tag/src/main/java/com/tgyuu/tag/graph/main/contract/TagIntent.kt
+++ b/feature/tag/src/main/java/com/tgyuu/tag/graph/main/contract/TagIntent.kt
@@ -5,6 +5,7 @@ import com.tgyuu.designsystem.model.TodoTagUiModel
 
 sealed class TagIntent : UiIntent {
     data object OnBackClick : TagIntent()
+    data object OnAddClick : TagIntent()
     data class OnEditClick(val tag: TodoTagUiModel) : TagIntent()
     data class OnDeleteClick(val tag: TodoTagUiModel) : TagIntent()
 }


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용

태그 관리 / 반복 주기 관리 화면에 항목을 추가할 수 있는 진입점과 빈 상태 UI를 추가했습니다.

- **추가 버튼**: 상단바 우측에 일정 추가 화면의 '저장' 버튼과 동일한 스타일(`body16M` / `primaryNormal`)의 **'추가' 텍스트 버튼**을 추가하여, 각각 태그 추가 / 반복 주기 추가 화면으로 이동합니다.
- **Empty UI**: 목록이 비어있을 때 남은 공간 중앙에 안내 문구를 노출합니다. (홈 빈 상태와 동일한 `body14M` / `textDisabled` 스타일)
- **Analytics**: 추가 버튼 클릭 시 `Click` 로그를 기록합니다. (`AddTag`, `AddRepeatCycle`)

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!

- `OnAddClick` 인텐트 → ViewModel에서 로깅 후 `NavigationEvent.To`로 이동하는 기존 `OnEditClick` 패턴을 그대로 따랐습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 반복 주기 목록에 항목 추가 버튼을 추가했습니다.
  * 태그 목록에 항목 추가 버튼을 추가했습니다.
  * 빈 반복 주기 목록과 빈 태그 목록에 안내 메시지를 표시하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->