### PR TITLE
fix: 위젯 할 일 체크 시 다른 항목이 토글되는 버그 수정

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/calendar/CalendarWidget.kt
@@ -484,7 +484,10 @@ private fun ColumnScope.SelectedDateTodoList(
             LazyColumn(
                 modifier = GlanceModifier.fillMaxSize()
             ) {
-                items(items = todoLists) { item ->
+                items(
+                    items = todoLists,
+                    itemId = { it.id.toLong() },
+                ) { item ->
                     TodoItemRow(
                         todo = item,
                         modifier = GlanceModifier.fillMaxWidth()

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/todaytodo/TodayTodoWidget.kt
@@ -244,7 +244,10 @@ private fun TodayTodoWidgetContent(
                 modifier = GlanceModifier.fillMaxSize()
                     .padding(top = 6.dp),
             ) {
-                items(items = todoLists.fastMapIndexed { i, it -> i to it }) { (index, item) ->
+                items(
+                    items = todoLists.fastMapIndexed { i, it -> i to it },
+                    itemId = { (_, item) -> item.id.toLong() },
+                ) { (index, item) ->
                     val titleBitmap = if (item.isDone) bitmaps.titlesDone.getOrNull(index)
                         else bitmaps.titles.getOrNull(index)
                     TodoItemRow(


### PR DESCRIPTION
Glance LazyColumn에 고유 itemId가 없어 각 행의 체크 액션
PendingIntent 파라미터(todoId)가 행끼리 섞이는 문제가 있었음.
이로 인해 특정 순위 항목을 체크해도 다른 항목이 토글되고,
재정렬되면서 엉뚱한 항목의 태그 색/줄긋기가 바뀌어 보였음.

TodayTodo/Calendar 위젯 리스트에 todo의 실제 id를 itemId로
부여해 행별 액션 파라미터가 고유하게 유지되도록 수정.

## 1. ⭐️ 변경된 내용 

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 달력 위젯 및 오늘의 할일 위젯에서 목록 항목의 안정적인 식별 처리를 개선하여 항목 렌더링 및 상태 관리의 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->