### PR TITLE
feat: 홈 카드에 현재 복습 회차 동그라미 밑줄 강조

### DIFF
--- a/core/designsystem/src/main/java/com/tgyuu/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/com/tgyuu/designsystem/component/Card.kt
@@ -3,15 +3,18 @@ package com.tgyuu.designsystem.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -94,12 +97,28 @@ fun TodoListCard(
                         ) {
                             FlowRow(modifier = Modifier.weight(1f)) {
                                 todosWithSameInfo.forEach {
-                                    EbbingCheck(
-                                        checked = it.isDone,
-                                        colorValue = it.color,
-                                        onCheckedChange = {},
-                                        modifier = Modifier.size(20.dp),
-                                    )
+                                    val isCurrent = it.id == todo.id
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                        EbbingCheck(
+                                            checked = it.isDone,
+                                            colorValue = it.color,
+                                            onCheckedChange = {},
+                                            modifier = Modifier.size(20.dp),
+                                        )
+
+                                        Spacer(modifier = Modifier.height(2.dp))
+
+                                        Box(
+                                            modifier = Modifier
+                                                .height(2.dp)
+                                                .width(12.dp)
+                                                .clip(RoundedCornerShape(1.dp))
+                                                .background(
+                                                    if (isCurrent) Color(it.color)
+                                                    else Color.Transparent
+                                                ),
+                                        )
+                                    }
                                 }
                             }
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeViewModel.kt
@@ -552,7 +552,7 @@ class HomeViewModel @Inject constructor(
         schedules: List<TodoSchedule>,
     ): ImmutableMap<Int, ImmutableList<TodoScheduleUiModel>> {
         return schedules.groupBy { it.infoId }.mapValues { (_, list) ->
-            list.toUiModels()
+            list.sortedBy { it.date }.toUiModels()
         }.toImmutableMap()
     }
 


### PR DESCRIPTION
같은 학습의 전체 복습 일정 동그라미가 어느 날짜 카드든 동일하게
보여 현재 항목이 첫 공부인지 몇 회차 복습인지 구분이 어려웠음.

현재 카드 날짜에 해당하는 회차 동그라미 아래에만 밑줄을 표시해
직관적으로 구분되도록 함. 회차 순서가 실제 복습 순서와 맞도록
buildByInfoMap에서 일정을 날짜순 정렬.

## 1. ⭐️ 변경된 내용 

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!