### PR TITLE
fix: 동기화 업로드 시 priority 등 NOT NULL 컬럼 누락 제약 위반 수정

### DIFF
--- a/core/network/src/main/java/com/tgyuu/network/model/sync/RepeatCycleDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/RepeatCycleDto.kt
@@ -3,16 +3,17 @@ package com.tgyuu.network.model.sync
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
 import com.tgyuu.network.util.toLocalDateTimeFromUtc
 import com.tgyuu.network.util.toUtcIsoString
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class RepeatCycleDto(
-    val id: Int = -1,
-    val uuid: String = "",
-    val intervals: List<Int> = emptyList(),
-    @SerialName("is_deleted") val isDeleted: Boolean = false,
-    @SerialName("updated_at") val updatedAt: String = "",
+    @EncodeDefault val id: Int = -1,
+    @EncodeDefault val uuid: String = "",
+    @EncodeDefault val intervals: List<Int> = emptyList(),
+    @EncodeDefault @SerialName("is_deleted") val isDeleted: Boolean = false,
+    @EncodeDefault @SerialName("updated_at") val updatedAt: String = "",
     @SerialName("uploaded_at") val uploadedAt: String? = null,
 ) {
     fun toDomain() = RepeatCycleForSync(

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/TodoInfoDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/TodoInfoDto.kt
@@ -3,19 +3,20 @@ package com.tgyuu.network.model.sync
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.network.util.toLocalDateTimeFromUtc
 import com.tgyuu.network.util.toUtcIsoString
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.LocalDate
 
 @Serializable
 data class TodoInfoDto(
-    val id: Int = -1,
-    val uuid: String = "",
-    val title: String = "",
-    @SerialName("tag_id") val tagId: Int = -1,
-    @SerialName("rest_days") val restDays: String = "",
-    @SerialName("created_at") val createdAt: String = "",
-    @SerialName("updated_at") val updatedAt: String = "",
+    @EncodeDefault val id: Int = -1,
+    @EncodeDefault val uuid: String = "",
+    @EncodeDefault val title: String = "",
+    @EncodeDefault @SerialName("tag_id") val tagId: Int = -1,
+    @EncodeDefault @SerialName("rest_days") val restDays: String = "",
+    @EncodeDefault @SerialName("created_at") val createdAt: String = "",
+    @EncodeDefault @SerialName("updated_at") val updatedAt: String = "",
     @SerialName("uploaded_at") val uploadedAt: String? = null,
 ) {
     fun toDomain() = TodoInfoForSync(

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/TodoScheduleDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/TodoScheduleDto.kt
@@ -3,22 +3,23 @@ package com.tgyuu.network.model.sync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import com.tgyuu.network.util.toLocalDateTimeFromUtc
 import com.tgyuu.network.util.toUtcIsoString
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.LocalDate
 
 @Serializable
 data class TodoScheduleDto(
-    val id: Int = -1,
-    val uuid: String = "",
-    @SerialName("info_id") val infoId: Int = -1,
-    val date: String = "",
-    val memo: String = "",
-    val priority: Int = 0,
-    @SerialName("is_done") val isDone: Boolean = false,
-    @SerialName("is_deleted") val isDeleted: Boolean = false,
-    @SerialName("created_at") val createdAt: String = "",
-    @SerialName("updated_at") val updatedAt: String = "",
+    @EncodeDefault val id: Int = -1,
+    @EncodeDefault val uuid: String = "",
+    @EncodeDefault @SerialName("info_id") val infoId: Int = -1,
+    @EncodeDefault val date: String = "",
+    @EncodeDefault val memo: String = "",
+    @EncodeDefault val priority: Int = 0,
+    @EncodeDefault @SerialName("is_done") val isDone: Boolean = false,
+    @EncodeDefault @SerialName("is_deleted") val isDeleted: Boolean = false,
+    @EncodeDefault @SerialName("created_at") val createdAt: String = "",
+    @EncodeDefault @SerialName("updated_at") val updatedAt: String = "",
     @SerialName("uploaded_at") val uploadedAt: String? = null,
 ) {
     fun toDomain(): TodoScheduleForSync = TodoScheduleForSync(

--- a/core/network/src/main/java/com/tgyuu/network/model/sync/TodoTagDto.kt
+++ b/core/network/src/main/java/com/tgyuu/network/model/sync/TodoTagDto.kt
@@ -3,19 +3,20 @@ package com.tgyuu.network.model.sync
 import com.tgyuu.domain.model.sync.TodoTagForSync
 import com.tgyuu.network.util.toLocalDateTimeFromUtc
 import com.tgyuu.network.util.toUtcIsoString
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.LocalDate
 
 @Serializable
 data class TodoTagDto(
-    val id: Int = -1,
-    val uuid: String = "",
-    val name: String = "",
-    val color: Int = -1,
-    @SerialName("is_deleted") val isDeleted: Boolean = false,
-    @SerialName("created_at") val createdAt: String = "",
-    @SerialName("updated_at") val updatedAt: String = "",
+    @EncodeDefault val id: Int = -1,
+    @EncodeDefault val uuid: String = "",
+    @EncodeDefault val name: String = "",
+    @EncodeDefault val color: Int = -1,
+    @EncodeDefault @SerialName("is_deleted") val isDeleted: Boolean = false,
+    @EncodeDefault @SerialName("created_at") val createdAt: String = "",
+    @EncodeDefault @SerialName("updated_at") val updatedAt: String = "",
     @SerialName("uploaded_at") val uploadedAt: String? = null,
 ) {
     fun toDomain() = TodoTagForSync(


### PR DESCRIPTION
## 문제
프로덕션 Non-fatal:
```
null value in column "priority" of relation "todo_schedules" violates not-null constraint
POST /rest/v1/todo_schedules?columns=id,uuid,info_id,date,is_done,created_at,updated_at,priority,is_deleted
```

## 원인
여러 일정을 한 번에 `upsert`할 때 kotlinx serialization이 **기본값 필드를 직렬화에서 생략**함 (`priority=0`, `is_done=false` 등). PostgREST는 배치 내 행들의 키 **합집합**으로 `columns`를 구성하므로, 한 행이라도 `priority`를 보내면 → 생략한 다른 행들에는 NULL이 들어가 NOT NULL 제약을 위반함. `priority`가 먼저 드러났을 뿐 `is_done`/`is_deleted`/`color`도 동일한 잠재 버그였음.

## 수정
업로드 DTO 4종(`TodoScheduleDto`/`TodoInfoDto`/`RepeatCycleDto`/`TodoTagDto`)의 모든 업로드 필드에 `@EncodeDefault`를 추가해 항상 직렬화되도록 함. 배치 내 모든 행이 동일한 컬럼 셋을 보내므로 NULL 합집합 문제가 사라짐.

`uploaded_at`은 서버 관리 컬럼이자 다운로드 변경분 필터(`gt("uploaded_at", ...)`) 기준이라 **의도적으로 제외**.

### 전역 encodeDefaults=true를 쓰지 않은 이유
- `SyncInfoDto` upsert 시 빈 문자열 timestamp(`""`) 전송 → 파싱 실패
- `uploaded_at`이 null로 전송 → 서버 관리 값 덮어씀

## 영향 범위
직렬화(업로드)만 변경, 역직렬화(다운로드)는 영향 없음. `:core:network` 컴파일 통과.

## 확인 필요
`uploaded_at`을 서버 트리거/기본값으로 자동 세팅한다는 가정 하에 업로드에서 제외함. 클라이언트가 채워야 하는 컬럼이면 `toDto`에 추가 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 동기화 데이터에 업로드 타임스탬프 필드 추가

* **개선사항**
  * 동기화 시 기본값을 포함한 데이터 전송 방식 개선으로 데이터 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->