### PR TITLE
fix: 위젯 DataStore 동시 접근 크래시 방지

### DIFF
--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/Actions.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/Actions.kt
@@ -17,6 +17,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
 
 const val KEY_DESTINATION = "destination"
@@ -94,13 +95,15 @@ class SelectDateAction : ActionCallback {
         // 이번 달이 아니라면 보여주지 않음
         if (date.monthValue != today.monthValue) return
 
-        updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { prefs ->
-            prefs.toMutablePreferences().apply {
-                this[SELECTED_DATE] = date.toString()
+        widgetStateMutex.withLock {
+            updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { prefs ->
+                prefs.toMutablePreferences().apply {
+                    this[SELECTED_DATE] = date.toString()
+                }
             }
-        }
 
-        CalendarWidget().update(context, glanceId)
+            CalendarWidget().update(context, glanceId)
+        }
     }
 
     companion object {

--- a/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/WidgetUpdater.kt
+++ b/feature/widget/src/main/java/com/tgyuu/ebbingplanner/widget/util/WidgetUpdater.kt
@@ -27,9 +27,18 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
-object WidgetUpdater {
+/**
+ * 모든 위젯 상태(DataStore) 접근을 직렬화하기 위한 프로세스 전역 Mutex.
+ *
+ * Glance 의 PreferencesGlanceStateDefinition 은 위젯 1개당 단일 DataStore 파일
+ * (`appWidget-<id>.preferences_pb`)을 사용하는데, 같은 파일에 대해 DataStore 가
+ * 동시에 2개 이상 활성화되면 "There are multiple DataStores active for the same file"
+ * IllegalStateException 으로 크래시가 발생한다. updateAppWidgetState /
+ * GlanceAppWidget.update 호출을 모두 이 락으로 감싸 동시 접근을 막는다.
+ */
+internal val widgetStateMutex = Mutex()
 
-    private val mutex = Mutex()
+object WidgetUpdater {
 
     suspend fun updateTodayTodoWidget(
         context: Context,
@@ -55,16 +64,18 @@ object WidgetUpdater {
         val json = GsonProvider.gson.toJson(todoLists)
         val widget = TodayTodoWidget()
 
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { pref ->
-                pref.toMutablePreferences().apply {
-                    this[TodayTodoWidgetReceiver.TODO_LISTS] = json
-                    this[THEME] = theme.name
-                    this[BACKGROUND_ALPHA] = backgroundAlpha
-                    this[TEXT_ALPHA] = textAlpha
+        widgetStateMutex.withLock {
+            glanceIds.forEach { glanceId ->
+                updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { pref ->
+                    pref.toMutablePreferences().apply {
+                        this[TodayTodoWidgetReceiver.TODO_LISTS] = json
+                        this[THEME] = theme.name
+                        this[BACKGROUND_ALPHA] = backgroundAlpha
+                        this[TEXT_ALPHA] = textAlpha
+                    }
                 }
+                widget.update(context, glanceId)
             }
-            widget.update(context, glanceId)
         }
     }
 
@@ -99,17 +110,19 @@ object WidgetUpdater {
         val json = GsonProvider.gson.toJson(byDate)
         val widget = CalendarWidget()
 
-        glanceIds.forEach { glanceId ->
-            updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { pref ->
-                pref.toMutablePreferences().apply {
-                    this[CalendarWidgetReceiver.SCHEDULES_BY_DATE_MAP] = json
-                    this[THEME] = theme.name
-                    this[BACKGROUND_ALPHA] = backgroundAlpha
-                    this[TEXT_ALPHA] = textAlpha
-                    this[WIDGET_MONDAY_START] = mondayStart
+        widgetStateMutex.withLock {
+            glanceIds.forEach { glanceId ->
+                updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { pref ->
+                    pref.toMutablePreferences().apply {
+                        this[CalendarWidgetReceiver.SCHEDULES_BY_DATE_MAP] = json
+                        this[THEME] = theme.name
+                        this[BACKGROUND_ALPHA] = backgroundAlpha
+                        this[TEXT_ALPHA] = textAlpha
+                        this[WIDGET_MONDAY_START] = mondayStart
+                    }
                 }
+                widget.update(context, glanceId)
             }
-            widget.update(context, glanceId)
         }
     }
 
@@ -117,7 +130,9 @@ object WidgetUpdater {
         context: Context,
         todoRepository: TodoRepository,
         configRepository: ConfigRepository,
-    ) = mutex.withLock {
+    ) {
+        // 각 함수가 내부에서 widgetStateMutex 로 DataStore 접근을 직렬화하므로
+        // 여기서 별도로 락을 잡지 않는다. (Mutex 는 재진입 불가 → 잡으면 데드락)
         updateTodayTodoWidget(context, todoRepository, configRepository)
         updateCalendarWidget(context, todoRepository, configRepository)
     }


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용

위젯 상태(DataStore) 동시 접근으로 발생하던 크래시를 프로세스 전역 Mutex로 직렬화해 방지했습니다.

- `WidgetUpdater`에 있던 `private val mutex`를 파일 레벨 `internal val widgetStateMutex`로 승격
- `updateTodayTodoWidget` / `updateCalendarWidget`의 `updateAppWidgetState` + `GlanceAppWidget.update` 호출을 모두 `widgetStateMutex.withLock`으로 감쌈
- `SelectDateAction`(Actions.kt)의 날짜 선택 시 위젯 갱신도 동일 락으로 감쌈
- `updateAllWidget`은 내부 함수들이 각자 락을 잡으므로 별도 락 제거 (Mutex 재진입 불가 → 데드락 방지)

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

Glance의 `PreferencesGlanceStateDefinition`은 위젯 1개당 단일 DataStore 파일(`appWidget-<id>.preferences_pb`)을 사용하는데, 같은 파일에 DataStore가 동시에 2개 이상 활성화되면 `There are multiple DataStores active for the same file` IllegalStateException으로 크래시가 발생합니다.

## 4. 📌 이 부분은 꼭 봐주세요!

`kotlinx.coroutines.sync.Mutex`는 재진입(reentrant)이 불가능해서, 락을 잡은 함수 안에서 또 같은 락을 잡으면 데드락이 됩니다. 그래서 `updateAllWidget`에서는 의도적으로 락을 잡지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 위젯의 날짜 선택 및 상태 갱신이 더 안정적으로 처리되도록 개선했습니다.
  * 여러 위젯 업데이트가 동시에 발생해도 상태 저장 충돌이나 갱신 누락이 줄어들도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->