### PR TITLE
fix(sync): 업로드 실패가 QR 발급을 막지 않도록 분리 + 진단 로깅

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
     implementation(projects.core.datastore)
     implementation(projects.core.common)
     implementation(projects.core.deviceInfo)
+
+    testImplementation(libs.mockk)
 }

--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -13,6 +13,8 @@ import com.tgyuu.domain.model.sync.ServerSyncInfo
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
 import com.tgyuu.domain.model.sync.TodoTagForSync
+import com.tgyuu.common.suspendRunCatching
+import com.tgyuu.domain.repository.ErrorRepository
 import com.tgyuu.domain.repository.SyncRepository
 import com.tgyuu.network.source.SyncRemoteDataSource
 import kotlinx.coroutines.async
@@ -32,6 +34,7 @@ class SyncRepositoryImpl @Inject constructor(
     private val localSyncDataSource: LocalSyncDataSource,
     private val localSyncTransactionDataSource: LocalSyncTransactionDataSource,
     private val deviceInfoProvider: DeviceInfoProvider,
+    private val errorRepository: ErrorRepository,
 ) : SyncRepository {
     override suspend fun ensureUUIDExists() = localSyncDataSource.ensureUUIDExists()
     override suspend fun getUuid(): String = localSyncDataSource.uuid.first()
@@ -63,7 +66,8 @@ class SyncRepositoryImpl @Inject constructor(
 
     override suspend fun generateConnectCode(connectCode: String): ZonedDateTime =
         coroutineScope {
-            uploadData()
+            suspendRunCatching { uploadData() }
+                .onFailure { errorRepository.logError(it) }
 
             val response = syncDataSource.generateConnectCode(
                 uuid = getUuid(),

--- a/core/data/src/test/java/com/tgyuu/data/repository/SyncRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/tgyuu/data/repository/SyncRepositoryImplTest.kt
@@ -1,0 +1,91 @@
+package com.tgyuu.data.repository
+
+import com.tgyuu.database.source.repeatcycle.LocalRepeatCycleDataSource
+import com.tgyuu.database.source.sync.LocalSyncTransactionDataSource
+import com.tgyuu.database.source.tag.LocalTagDataSource
+import com.tgyuu.database.source.todo.LocalTodoDataSource
+import com.tgyuu.datastore.datasource.sync.LocalSyncDataSource
+import com.tgyuu.deviceinfo.DeviceInfoProvider
+import com.tgyuu.domain.repository.ErrorRepository
+import com.tgyuu.network.source.SyncRemoteDataSource
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncRepositoryImplTest {
+    private val syncDataSource = mockk<SyncRemoteDataSource>(relaxed = true)
+    private val localTagDataSource = mockk<LocalTagDataSource>(relaxed = true)
+    private val localTodoDataSource = mockk<LocalTodoDataSource>(relaxed = true)
+    private val localRepeatCycleDataSource = mockk<LocalRepeatCycleDataSource>(relaxed = true)
+    private val localSyncDataSource = mockk<LocalSyncDataSource>(relaxed = true)
+    private val localSyncTransactionDataSource = mockk<LocalSyncTransactionDataSource>(relaxed = true)
+    private val deviceInfoProvider = mockk<DeviceInfoProvider>(relaxed = true)
+    private val errorRepository = mockk<ErrorRepository>(relaxed = true)
+
+    private lateinit var repository: SyncRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        every { localSyncDataSource.uuid } returns flowOf(UUID)
+        every { localSyncDataSource.connectedUuid } returns flowOf(null)
+        every { localSyncDataSource.lastSyncTime } returns flowOf(null)
+
+        repository = SyncRepositoryImpl(
+            syncDataSource = syncDataSource,
+            localTagDataSource = localTagDataSource,
+            localTodoDataSource = localTodoDataSource,
+            localRepeatCycleDataSource = localRepeatCycleDataSource,
+            localSyncDataSource = localSyncDataSource,
+            localSyncTransactionDataSource = localSyncTransactionDataSource,
+            deviceInfoProvider = deviceInfoProvider,
+            errorRepository = errorRepository,
+        )
+    }
+
+    @Test
+    fun `업로드가 실패해도 연동 코드는 발급되고 실패는 로깅된다`() = runTest {
+        coEvery {
+            syncDataSource.uploadData(any(), any(), any(), any(), any(), any())
+        } throws RuntimeException("server 500")
+        coEvery {
+            syncDataSource.generateConnectCode(any(), any(), any())
+        } returns FIXED_TIME
+
+        val result = repository.generateConnectCode(CONNECT_CODE)
+
+        assertEquals(FIXED_TIME, result)
+        coVerify { syncDataSource.generateConnectCode(UUID, CONNECT_CODE, any()) }
+        coVerify { errorRepository.logError(any()) }
+    }
+
+    @Test
+    fun `업로드 성공 시 연동 코드를 발급하고 에러를 로깅하지 않는다`() = runTest {
+        coEvery {
+            syncDataSource.uploadData(any(), any(), any(), any(), any(), any())
+        } returns FIXED_TIME
+        coEvery {
+            syncDataSource.generateConnectCode(any(), any(), any())
+        } returns FIXED_TIME
+
+        val result = repository.generateConnectCode(CONNECT_CODE)
+
+        assertEquals(FIXED_TIME, result)
+        coVerify { syncDataSource.generateConnectCode(UUID, CONNECT_CODE, any()) }
+        coVerify(exactly = 0) { errorRepository.logError(any()) }
+    }
+
+    private companion object {
+        private const val UUID = "uuid"
+        private const val CONNECT_CODE = "TESTCODE"
+        private val FIXED_TIME: ZonedDateTime = ZonedDateTime.parse("2026-01-01T00:00:00Z")
+    }
+}

--- a/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
@@ -50,42 +50,44 @@ class SupabaseSyncDataSource @Inject constructor(
         infos: List<TodoInfoForSync>,
         repeatCycles: List<RepeatCycleForSync>,
         tags: List<TodoTagForSync>,
-    ): ZonedDateTime = coroutineScope {
-        supabase.from(TABLE_SYNC_INFO)
-            .upsert(SyncInfoDto(uuid = uuid, deviceName = deviceName))
-
-        val schedulesJob = async {
-            if (schedules.isNotEmpty()) {
-                supabase.from(TABLE_SCHEDULES)
-                    .upsert(schedules.map { it.toDto(uuid) })
-            }
+    ): ZonedDateTime {
+        suspendRunCatching {
+            supabase.from(TABLE_SYNC_INFO)
+                .upsert(SyncInfoDto(uuid = uuid, deviceName = deviceName))
         }
 
-        val infosJob = async {
-            if (infos.isNotEmpty()) {
-                supabase.from(TABLE_TODO_INFOS)
-                    .upsert(infos.map { it.toDto(uuid) })
+        val scheduleDtos = schedules.map { it.toDto(uuid) }
+        val infoDtos = infos.map { it.toDto(uuid) }
+        val repeatCycleDtos = repeatCycles.map { it.toDto(uuid) }
+        val tagDtos = tags.map { it.toDto(uuid) }
+
+        val failures = mutableListOf<Throwable>()
+
+        uploadTable(TABLE_REPEAT_CYCLES, repeatCycleDtos) {
+            supabase.from(TABLE_REPEAT_CYCLES).upsert(repeatCycleDtos)
+        }?.let { failures += it }
+
+        val tagFailure = uploadTable(TABLE_TAGS, tagDtos) {
+            supabase.from(TABLE_TAGS).upsert(tagDtos)
+        }
+        tagFailure?.let { failures += it }
+
+        val infoFailure = if (tagFailure != null) {
+            null
+        } else {
+            uploadTable(TABLE_TODO_INFOS, infoDtos) {
+                supabase.from(TABLE_TODO_INFOS).upsert(infoDtos)
             }
         }
+        infoFailure?.let { failures += it }
 
-        val repeatCyclesJob = async {
-            if (repeatCycles.isNotEmpty()) {
-                supabase.from(TABLE_REPEAT_CYCLES)
-                    .upsert(repeatCycles.map { it.toDto(uuid) })
-            }
+        if (tagFailure == null && infoFailure == null) {
+            uploadTable(TABLE_SCHEDULES, scheduleDtos) {
+                supabase.from(TABLE_SCHEDULES).upsert(scheduleDtos)
+            }?.let { failures += it }
         }
 
-        val tagsJob = async {
-            if (tags.isNotEmpty()) {
-                supabase.from(TABLE_TAGS)
-                    .upsert(tags.map { it.toDto(uuid) })
-            }
-        }
-
-        schedulesJob.await()
-        infosJob.await()
-        repeatCyclesJob.await()
-        tagsJob.await()
+        if (failures.isNotEmpty()) throw failures.first()
 
         val now = ZonedDateTime.now()
         supabase.from(TABLE_SYNC_INFO)
@@ -96,7 +98,18 @@ class SupabaseSyncDataSource @Inject constructor(
                 filter { eq("uuid", uuid) }
             }
 
-        now
+        return now
+    }
+
+    private suspend fun uploadTable(
+        table: String,
+        rows: List<*>,
+        upsert: suspend () -> Unit,
+    ): Throwable? {
+        if (rows.isEmpty()) return null
+        return suspendRunCatching { upsert() }
+            .exceptionOrNull()
+            ?.let { SyncUploadException(table, rows, it) }
     }
 
     override suspend fun downloadData(

--- a/core/network/src/main/java/com/tgyuu/network/source/SyncUploadException.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SyncUploadException.kt
@@ -1,0 +1,15 @@
+package com.tgyuu.network.source
+
+class SyncUploadException(
+    table: String,
+    rows: List<*>,
+    cause: Throwable,
+) : Exception(
+    "Supabase upload failed [table=$table, rows=${rows.size}, " +
+        "payload=${rows.toString().take(PAYLOAD_LOG_LIMIT)}] cause=${cause.message}",
+    cause,
+) {
+    private companion object {
+        private const val PAYLOAD_LOG_LIMIT = 2000
+    }
+}


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용

`todo_schedules` upsert 실패가 **QR(연동 코드) 발급과 수동 동기화 전체를 죽이던 문제**를 외과적으로 막고, 병렬 업로드의 FK 위반 위험까지 함께 제거합니다.

- **`SupabaseSyncDataSource.uploadData`**
  - **FK 안전 순서로 순차 업로드**: `todo_tag → todo_info → schedule` (서버도 로컬과 동일한 FK 보유, `repeat_cycle`은 독립). 기존 4개 테이블 병렬 upsert는 자식이 부모보다 먼저 insert 되어 FK 위반이 날 수 있었음. 부모 실패 시 자식은 FK 위반이 확정이라 건너뜀.
  - **테이블별 내성**: 한 테이블 실패가 나머지를 취소하지 않음. 실패 시 진단정보(table/rows/payload)를 담은 `SyncUploadException`을 **던지기만** 하고, 로깅 정책은 상위 레이어에 위임 → datasource는 `ErrorDataSource`를 의존하지 않음.
- **`SyncRepositoryImpl`**
  - `generateConnectCode`의 `uploadData()`를 **best-effort로 분리** → 업로드 실패와 무관하게 연동 코드 발급. 삼킨 실패는 `ErrorRepository.logError`로만 기록(UI 미노출).
  - `syncUpData`는 기존처럼 예외 전파 → VM의 `errorBus`로 로깅됨(중복 로깅 제거).
- **`SyncUploadException`(신규)**: PostgREST 원본 에러(cause) 보존 + 실패 테이블/행 수/payload 샘플을 메시지에 담는 진단용 예외.
- **`SyncRepositoryImplTest`(신규, mockk)**: 업로드 실패 시에도 코드 발급 + 실패 로깅 / 업로드 성공 시 발급 + 미로깅 검증. (`:core:data:testDebugUnitTest` 2/2 통과)

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

- `schedule.memo`는 도메인·Room 엔티티·스키마 v1~v4(`notNull:true`)·sync 쿼리·DTO 전 계층에서 **non-null**. 로컬엔 NULL이 존재할 수 없어 on-read `COALESCE`/`UPDATE … WHERE memo IS NULL` 백필은 효과 없음(철회). NULL은 직렬화/전송 경계(supabase-kt bulk upsert의 `columns=` union)에서 생길 가능성이 유력.
- **서버 테이블이 로컬과 동일한 FK 체인**(`todo_tag ← todo_info ← schedule`)을 가져 병렬 upsert는 순서 보장이 안 됨 → 순차화 필요.
- 다운로드 삭제 경로는 안전: `hardDeleteTag`가 `@Transaction`으로 해당 태그의 `todo_info`를 기본 태그(id=1)로 재배정한 뒤 삭제하므로 FK 위반이 발생하지 않음(별도 수정 불필요).
- 에러 보고 경로: `ErrorBus.sendError` = UI 채널 + Crashlytics, `ErrorRepository.logError` = 로그 전용. best-effort로 삼키는 지점에는 후자가 적합.

## 4. 📌 이 부분은 꼭 봐주세요!

- `uploadData`는 **부분 실패 시 예외를 전파**합니다. 수동 동기화(`syncUpData`)는 기존처럼 실패가 노출되고, QR 경로만 best-effort로 분리했습니다. 의도한 동작이 맞는지 확인 부탁드려요.
- `memo` NOT NULL의 **근본 원인**은 진단 로깅(payload)으로 실제 실패 요청을 확보한 뒤 확정할 예정입니다. 후보였던 "supabase 클라이언트에 `encodeDefaults=true` Json 주입"은 `uploaded_at: null`까지 매 행 전송 → 서버 관리 컬럼을 덮어쓰고 증분 다운로드가 깨질 위험이 있어 이번엔 제외했습니다.