### PR TITLE
fix: isNetworkError가 cause 체인을 탐색하도록 개선

### DIFF
--- a/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
+++ b/core/common/src/main/java/com/tgyuu/common/NetworkErrorUtil.kt
@@ -1,5 +1,29 @@
 package com.tgyuu.common
 
 import java.io.IOException
+import java.net.UnknownHostException
 
-fun Throwable.isNetworkError(): Boolean = this is IOException
+/**
+ * 네트워크/DNS 도달 실패 여부를 판단한다.
+ *
+ * Supabase/Ktor 예외나 [com.tgyuu.network.source.SyncUploadException] 처럼
+ * 원인 예외가 여러 겹으로 감싸져 오는 경우가 많으므로, 최상위 타입만 보지 않고
+ * cause 체인 전체를 훑어 네트워크 계열 예외가 포함되어 있는지 확인한다.
+ */
+fun Throwable.isNetworkError(): Boolean = causeChain().any { throwable ->
+    throwable is IOException ||
+        throwable is UnknownHostException ||
+        throwable.isUnresolvedHostMessage()
+}
+
+private fun Throwable.isUnresolvedHostMessage(): Boolean {
+    val message = message ?: return false
+    return "Unable to resolve host" in message ||
+        "No address associated with hostname" in message
+}
+
+private fun Throwable.causeChain(): Sequence<Throwable> {
+    val seen = mutableSetOf<Throwable>()
+    // cause 가 자기 자신을 참조하는 순환 구조를 방어한다.
+    return generateSequence(this) { it.cause }.takeWhile { seen.add(it) }
+}


### PR DESCRIPTION
래핑된 예외(SyncUploadException, Ktor 예외 등)의 최상위 타입만 보던 isNetworkError를 cause 체인 전체를 훑도록 변경한다.

기존에는 SyncUploadException(Exception 상속)이나 Ktor 예외로 감싸진 UnknownHostException이 네트워크 에러로 분류되지 않아, 오프라인 사용자가
sync/QR 생성 시 '네트워크 확인' 대신 일반 실패 메시지를 보게 됐다.
cause 체인에서 IOException/UnknownHostException 또는 호스트 해석 실패 메시지를 확인해 올바르게 분류한다.

## 1. ⭐️ 변경된 내용 

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!