### PR TITLE
feat(sync): deviceId로 백업 데이터 복원

### DIFF
--- a/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/MainActivity.kt
@@ -210,7 +210,7 @@ class MainActivity : ComponentActivity() {
 
             launch {
                 navigationBus.navigationFlow.collect { event ->
-                    eventBus.sendEvent(EbbingEvent.HideSnackBar)
+                    snackBarHostState.currentSnackbarData?.dismiss()
 
                     when (event) {
                         is NavigationEvent.To -> {

--- a/app/src/main/java/com/tgyuu/ebbingplanner/ui/AppUiPolicy.kt
+++ b/app/src/main/java/com/tgyuu/ebbingplanner/ui/AppUiPolicy.kt
@@ -26,6 +26,7 @@ object AppUiPolicy {
         MemoGraph.AddMemoRoute::class,
         MemoGraph.EditMemoRoute::class,
         SyncGraph.SyncMainRoute::class,
+        SyncGraph.RestoreByDeviceIdRoute::class,
     )
 
     val rootRoutes = setOf(
@@ -35,5 +36,6 @@ object AppUiPolicy {
 
     val networkRequiredRoutes = setOf(
         SyncGraph.SyncMainRoute::class,
+        SyncGraph.RestoreByDeviceIdRoute::class,
     )
 }

--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.tgyuu.deviceinfo.DeviceInfoProvider
 import com.tgyuu.domain.model.sync.ConnectResult
 import com.tgyuu.domain.model.sync.ConnectedPeer
 import com.tgyuu.domain.model.sync.RepeatCycleForSync
+import com.tgyuu.domain.model.sync.RestoreResult
 import com.tgyuu.domain.model.sync.ServerSyncInfo
 import com.tgyuu.domain.model.sync.TodoInfoForSync
 import com.tgyuu.domain.model.sync.TodoScheduleForSync
@@ -126,6 +127,40 @@ class SyncRepositoryImpl @Inject constructor(
         )
         localSyncDataSource.setLinkCode(connectCode)
         return ConnectResult.Success(info)
+    }
+
+    override suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult {
+        val prefix = deviceIdPrefix.trim()
+            .substringAfterLast('·')
+            .substringAfterLast(' ')
+            .trim()
+            .lowercase()
+
+        if (prefix.length < UUID_PREFIX_MIN_LENGTH) return RestoreResult.NotFound
+        if (prefix.any { it !in UUID_ALLOWED_CHARS }) return RestoreResult.NotFound
+        if (getUuid().lowercase().startsWith(prefix)) return RestoreResult.SelfDevice
+
+        val matches = syncDataSource.findSyncInfosByUuidPrefix(prefix).getOrThrow()
+        val target = when {
+            matches.isEmpty() -> return RestoreResult.NotFound
+            matches.size > 1 -> return RestoreResult.Ambiguous
+            else -> matches.first()
+        }
+
+        val response = syncDataSource.downloadData(target.uuid, Date(0L)).getOrThrow()
+
+        val hasAliveData = response.todoInfos.isNotEmpty() &&
+            response.schedules.any { !it.isDeleted }
+        if (!hasAliveData) return RestoreResult.EmptyData
+
+        localSyncTransactionDataSource.replaceAllData(
+            infos = response.todoInfos,
+            repeatCycles = response.repeatCycles,
+            tags = response.tags,
+            schedules = response.schedules,
+        )
+
+        return RestoreResult.Success(target.deviceName)
     }
 
     override suspend fun disconnectAnother() {
@@ -354,5 +389,7 @@ class SyncRepositoryImpl @Inject constructor(
 
     private companion object {
         val EPOCH: LocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 0)
+        const val UUID_PREFIX_MIN_LENGTH = 8
+        const val UUID_ALLOWED_CHARS = "0123456789abcdef-"
     }
 }

--- a/core/database/src/main/java/com/tgyuu/database/source/sync/LocalSyncTransactionDataSourceImpl.kt
+++ b/core/database/src/main/java/com/tgyuu/database/source/sync/LocalSyncTransactionDataSourceImpl.kt
@@ -16,10 +16,26 @@ class LocalSyncTransactionDataSourceImpl @Inject constructor(
         tags: List<TodoTagForSync>,
         schedules: List<TodoScheduleForSync>,
         repeatCycles: List<RepeatCycleForSync>,
-    ) = syncDao.replaceAllData(
-        infos = infos.map(TodoInfoForSync::toEntity),
-        tags = tags.map(TodoTagForSync::toEntity),
-        schedules = schedules.map(TodoScheduleForSync::toEntity),
-        repeatCycles = repeatCycles.map(RepeatCycleForSync::toEntity),
-    )
+    ) {
+        val tagEntities = tags.map(TodoTagForSync::toEntity)
+        val tagIds = tagEntities.map { it.id }.toSet() + DEFAULT_TAG_ID
+
+        val infoEntities = infos.map(TodoInfoForSync::toEntity)
+            .filter { it.tagId in tagIds }
+        val infoIds = infoEntities.map { it.id }.toSet()
+
+        val scheduleEntities = schedules.map(TodoScheduleForSync::toEntity)
+            .filter { it.infoId in infoIds }
+
+        syncDao.replaceAllData(
+            infos = infoEntities,
+            tags = tagEntities,
+            schedules = scheduleEntities,
+            repeatCycles = repeatCycles.map(RepeatCycleForSync::toEntity),
+        )
+    }
+
+    private companion object {
+        private const val DEFAULT_TAG_ID = 1
+    }
 }

--- a/core/designsystem/src/main/res/values-en/strings.xml
+++ b/core/designsystem/src/main/res/values-en/strings.xml
@@ -40,6 +40,21 @@
     <string name="sync_network_connect_action">Connect</string>
     <string name="sync_network_required">No network connection.</string>
     <string name="sync_network_check">Please check your network connection.</string>
+    <string name="sync_restore_title">Restore data</string>
+    <string name="sync_restore_headline">Restore your backed-up data</string>
+    <string name="sync_restore_description">Enter the deviceId shown on the other device\'s sync screen to bring its backed-up data to this device.</string>
+    <string name="sync_restore_input_label">deviceId</string>
+    <string name="sync_restore_input_hint">e.g. 3f2a8b1c</string>
+    <string name="sync_restore_button">Restore</string>
+    <string name="sync_restore_done">Restored data from %1$s.</string>
+    <string name="sync_restore_not_found">No backup found for that deviceId.</string>
+    <string name="sync_restore_empty_data">That device\'s backup is empty. If it was linked to another device, try that device\'s deviceId instead.</string>
+    <string name="sync_restore_ambiguous">Multiple devices match. Please check the deviceId again.</string>
+    <string name="sync_restore_self">That\'s this device\'s deviceId. Please enter another device\'s deviceId.</string>
+    <string name="sync_restore_failed">Restore failed. Please try again later.</string>
+    <string name="sync_restore_confirm_title">Restore data?</string>
+    <string name="sync_restore_confirm_desc">All data on this device will be replaced and cannot be undone.</string>
+    <string name="sync_restore_confirm_cancel">Go back</string>
 
     <!-- Main screen -->
     <string name="sync_title">Use on Other Devices</string>

--- a/core/designsystem/src/main/res/values-ja/strings.xml
+++ b/core/designsystem/src/main/res/values-ja/strings.xml
@@ -40,6 +40,21 @@
     <string name="sync_network_connect_action">接続する</string>
     <string name="sync_network_required">ネットワークに接続されていません。</string>
     <string name="sync_network_check">ネットワーク接続を確認してください。</string>
+    <string name="sync_restore_title">データ復元</string>
+    <string name="sync_restore_headline">バックアップデータを復元します</string>
+    <string name="sync_restore_description">他の端末の同期画面に表示されたdeviceIdを入力すると、その端末のバックアップデータをこの端末に取り込みます。</string>
+    <string name="sync_restore_input_label">deviceId</string>
+    <string name="sync_restore_input_hint">例) 3f2a8b1c</string>
+    <string name="sync_restore_button">復元する</string>
+    <string name="sync_restore_done">%1$sのデータを復元しました。</string>
+    <string name="sync_restore_not_found">そのdeviceIdのバックアップが見つかりませんでした。</string>
+    <string name="sync_restore_empty_data">その端末のバックアップは空です。他の端末と連携していた場合は、連携先端末のdeviceIdでお試しください。</string>
+    <string name="sync_restore_ambiguous">一致する端末が複数あります。deviceIdをもう一度確認してください。</string>
+    <string name="sync_restore_self">この端末のdeviceIdです。他の端末のdeviceIdを入力してください。</string>
+    <string name="sync_restore_failed">復元に失敗しました。しばらくしてから再度お試しください。</string>
+    <string name="sync_restore_confirm_title">データを復元しますか？</string>
+    <string name="sync_restore_confirm_desc">この端末のデータはすべて置き換えられ、元に戻せません。</string>
+    <string name="sync_restore_confirm_cancel">戻る</string>
 
     <!-- メイン画面 -->
     <string name="sync_title">他の端末でも使う</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -40,6 +40,21 @@
     <string name="sync_network_connect_action">연결하기</string>
     <string name="sync_network_required">네트워크가 연결되어 있지 않습니다.</string>
     <string name="sync_network_check">네트워크 연결을 확인해 주세요.</string>
+    <string name="sync_restore_title">데이터 복원</string>
+    <string name="sync_restore_headline">백업 데이터를 복원해요</string>
+    <string name="sync_restore_description">다른 기기의 동기화 화면에 표시된 deviceId를 입력하면, 해당 기기가 백업한 데이터를 이 기기로 가져와요.</string>
+    <string name="sync_restore_input_label">deviceId</string>
+    <string name="sync_restore_input_hint">예) 3f2a8b1c</string>
+    <string name="sync_restore_button">복원하기</string>
+    <string name="sync_restore_done">%1$s 기기의 데이터를 복원했어요.</string>
+    <string name="sync_restore_not_found">해당 deviceId의 백업 데이터를 찾지 못했어요.</string>
+    <string name="sync_restore_empty_data">해당 기기의 백업 데이터가 비어 있어요. 다른 기기와 연동해 사용했다면, 연동했던 기기의 deviceId로 시도해 주세요.</string>
+    <string name="sync_restore_ambiguous">일치하는 기기가 여러 개예요. deviceId를 다시 확인해 주세요.</string>
+    <string name="sync_restore_self">현재 기기의 deviceId예요. 다른 기기의 deviceId를 입력해 주세요.</string>
+    <string name="sync_restore_failed">복원에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="sync_restore_confirm_title">데이터를 복원할까요?</string>
+    <string name="sync_restore_confirm_desc">현재 기기의 데이터가 모두 교체되며, 되돌릴 수 없어요.</string>
+    <string name="sync_restore_confirm_cancel">돌아가기</string>
 
     <!-- 메인 화면 -->
     <string name="sync_title">다른 기기에서도 사용하기</string>

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/RestoreResult.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/RestoreResult.kt
@@ -1,0 +1,9 @@
+package com.tgyuu.domain.model.sync
+
+sealed interface RestoreResult {
+    data class Success(val deviceName: String) : RestoreResult
+    data object NotFound : RestoreResult
+    data object EmptyData : RestoreResult
+    data object Ambiguous : RestoreResult
+    data object SelfDevice : RestoreResult
+}

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/SyncRepository.kt
@@ -2,6 +2,7 @@ package com.tgyuu.domain.repository
 
 import com.tgyuu.domain.model.sync.ConnectResult
 import com.tgyuu.domain.model.sync.ConnectedPeer
+import com.tgyuu.domain.model.sync.RestoreResult
 import com.tgyuu.domain.model.sync.ServerSyncInfo
 import java.time.ZonedDateTime
 
@@ -17,6 +18,7 @@ interface SyncRepository {
     suspend fun getMyConnectCode(): String?
     suspend fun getConnectCodeExpiration(): ZonedDateTime?
     suspend fun connectAnother(connectCode: String): ConnectResult
+    suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult
     suspend fun disconnectAnother()
     suspend fun pollConnectedPeer(): ConnectedPeer?
     suspend fun getStoredPeer(): ConnectedPeer?

--- a/core/navigation/src/main/java/com/tgyuu/navigation/Route.kt
+++ b/core/navigation/src/main/java/com/tgyuu/navigation/Route.kt
@@ -94,4 +94,7 @@ sealed interface SyncGraph : Route {
 
     @Serializable
     data object SyncMainRoute : SyncGraph
+
+    @Serializable
+    data object RestoreByDeviceIdRoute : SyncGraph
 }

--- a/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
@@ -43,6 +43,14 @@ class SupabaseSyncDataSource @Inject constructor(
         )
     }
 
+    override suspend fun findSyncInfosByUuidPrefix(prefix: String): Result<List<SyncDeviceMatch>> =
+        suspendRunCatching {
+            supabase.from(TABLE_SYNC_INFO)
+                .select { filter { ilike("uuid", "$prefix%") } }
+                .decodeList<SyncInfoDto>()
+                .map { SyncDeviceMatch(uuid = it.uuid, deviceName = it.deviceName) }
+        }
+
     override suspend fun uploadData(
         uuid: String,
         deviceName: String,

--- a/core/network/src/main/java/com/tgyuu/network/source/SyncRemoteDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SyncRemoteDataSource.kt
@@ -14,6 +14,11 @@ data class SyncInfoResult(
     val deviceName: String,
 )
 
+data class SyncDeviceMatch(
+    val uuid: String,
+    val deviceName: String,
+)
+
 data class SyncDownloadResult(
     val schedules: List<TodoScheduleForSync>,
     val todoInfos: List<TodoInfoForSync>,
@@ -24,6 +29,7 @@ data class SyncDownloadResult(
 
 interface SyncRemoteDataSource {
     suspend fun getSyncInfo(uuid: String): SyncInfoResult?
+    suspend fun findSyncInfosByUuidPrefix(prefix: String): Result<List<SyncDeviceMatch>>
     suspend fun uploadData(
         uuid: String,
         deviceName: String,

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingScreen.kt
@@ -133,6 +133,7 @@ internal fun SettingRoute(
         onTagManageClick = { viewModel.onIntent(SettingIntent.OnTagManageClick) },
         onRepeatCycleManageClick = { viewModel.onIntent(SettingIntent.OnRepeatCycleManageClick) },
         onSyncClick = { viewModel.onIntent(SettingIntent.OnSyncClick) },
+        onRestoreByDeviceIdClick = { viewModel.onIntent(SettingIntent.OnRestoreByDeviceIdClick) },
         onClearClick = { viewModel.onIntent(SettingIntent.OnClearClick) },
         onAppThemeManageClick = { viewModel.onIntent(SettingIntent.OnAppThemeManageClick) },
         onWidgetManageClick = { viewModel.onIntent(SettingIntent.OnWidgetManageClick) },
@@ -166,6 +167,7 @@ private fun SettingScreen(
     onTagManageClick: () -> Unit,
     onRepeatCycleManageClick: () -> Unit,
     onSyncClick: () -> Unit,
+    onRestoreByDeviceIdClick: () -> Unit,
     onClearClick: () -> Unit,
     onAppThemeManageClick: () -> Unit,
     onWidgetManageClick: () -> Unit,
@@ -198,6 +200,7 @@ private fun SettingScreen(
             onTagManageClick = onTagManageClick,
             onRepeatCycleManageClick = onRepeatCycleManageClick,
             onSyncClick = onSyncClick,
+            onRestoreByDeviceIdClick = onRestoreByDeviceIdClick,
             onClearClick = { isShowClearConfirm = true },
             onAppThemeManageClick = onAppThemeManageClick,
             onWidgetManageClick = onWidgetManageClick,
@@ -218,6 +221,7 @@ private fun SettingScreen(
             onTagManageClick = onTagManageClick,
             onRepeatCycleManageClick = onRepeatCycleManageClick,
             onSyncClick = onSyncClick,
+            onRestoreByDeviceIdClick = onRestoreByDeviceIdClick,
             onClearClick = { isShowClearConfirm = true },
             onAppThemeManageClick = onAppThemeManageClick,
             onWidgetManageClick = onWidgetManageClick,
@@ -241,6 +245,7 @@ private fun PhoneSettingScreen(
     onTagManageClick: () -> Unit,
     onRepeatCycleManageClick: () -> Unit,
     onSyncClick: () -> Unit,
+    onRestoreByDeviceIdClick: () -> Unit,
     onClearClick: () -> Unit,
     onAppThemeManageClick: () -> Unit,
     onWidgetManageClick: () -> Unit,
@@ -306,6 +311,7 @@ private fun PhoneSettingScreen(
                 autoBackupEnabled = state.autoBackupEnabled,
                 lastSyncTime = state.lastSyncTime?.let { formatSyncTime(it) },
                 onSyncClick = onSyncClick,
+                onRestoreByDeviceIdClick = onRestoreByDeviceIdClick,
                 onClearClick = onClearClick,
                 onAutoBackupToggleClick = onAutoBackupToggleClick,
             )
@@ -333,6 +339,7 @@ private fun TabletSettingScreen(
     onTagManageClick: () -> Unit,
     onRepeatCycleManageClick: () -> Unit,
     onSyncClick: () -> Unit,
+    onRestoreByDeviceIdClick: () -> Unit,
     onClearClick: () -> Unit,
     onAppThemeManageClick: () -> Unit,
     onWidgetManageClick: () -> Unit,
@@ -405,6 +412,7 @@ private fun TabletSettingScreen(
                     autoBackupEnabled = state.autoBackupEnabled,
                     lastSyncTime = state.lastSyncTime?.let { formatSyncTime(it) },
                     onSyncClick = onSyncClick,
+                    onRestoreByDeviceIdClick = onRestoreByDeviceIdClick,
                     onClearClick = onClearClick,
                     onAutoBackupToggleClick = onAutoBackupToggleClick,
                 )
@@ -667,6 +675,7 @@ private fun DataBody(
     autoBackupEnabled: Boolean,
     lastSyncTime: String?,
     onSyncClick: () -> Unit,
+    onRestoreByDeviceIdClick: () -> Unit,
     onClearClick: () -> Unit,
     onAutoBackupToggleClick: () -> Unit,
 ) {
@@ -730,6 +739,27 @@ private fun DataBody(
                 )
             }
         }
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = SettingItemVerticalPadding)
+            .clickable { onRestoreByDeviceIdClick() },
+    ) {
+        Text(
+            text = stringResource(R.string.sync_restore_title),
+            style = EbbingTheme.typography.heading16SB,
+            color = EbbingTheme.colors.textOnBackground,
+            modifier = Modifier.weight(1f),
+        )
+
+        Image(
+            painter = painterResource(R.drawable.ic_arrow_right),
+            contentDescription = stringResource(R.string.setting_detail_content),
+            modifier = Modifier.padding(start = 4.dp),
+        )
     }
 
     Row(
@@ -1106,6 +1136,7 @@ private fun PreviewSettingScreen() {
             onTagManageClick = {},
             onRepeatCycleManageClick = {},
             onSyncClick = {},
+            onRestoreByDeviceIdClick = {},
             onClearClick = {},
             onAppThemeManageClick = {},
             onWidgetManageClick = {},

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/SettingViewModel.kt
@@ -140,6 +140,7 @@ class SettingViewModel @Inject constructor(
             is SettingIntent.OnStartDayClick -> onStartDayClick(intent.content)
             is SettingIntent.OnUpdateStartDay -> onUpdateStartDay(intent.mondayStart)
             SettingIntent.OnAutoBackupToggleClick -> onAutoBackupToggleClick()
+            SettingIntent.OnRestoreByDeviceIdClick -> onRestoreByDeviceIdClick()
         }
     }
 
@@ -244,6 +245,13 @@ class SettingViewModel @Inject constructor(
             AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "SyncData")
         )
         navigationBus.navigate(To(SyncGraph.SyncMainRoute))
+    }
+
+    private suspend fun onRestoreByDeviceIdClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = SCREEN_NAME, buttonName = "RestoreByDeviceId")
+        )
+        navigationBus.navigate(To(SyncGraph.RestoreByDeviceIdRoute))
     }
 
     private suspend fun onAppThemeManageClick() {

--- a/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
+++ b/feature/setting/src/main/java/com/tgyuu/setting/graph/main/contract/SettingIntent.kt
@@ -25,4 +25,5 @@ sealed interface SettingIntent : UiIntent {
     data class OnStartDayClick(val content: BottomSheetContent) : SettingIntent
     data class OnUpdateStartDay(val mondayStart: Boolean) : SettingIntent
     data object OnAutoBackupToggleClick : SettingIntent
+    data object OnRestoreByDeviceIdClick : SettingIntent
 }

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreScreen.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreScreen.kt
@@ -1,0 +1,182 @@
+package com.tgyuu.sync.graph.restore
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tgyuu.designsystem.BasePreview
+import com.tgyuu.designsystem.EbbingPreview
+import com.tgyuu.designsystem.R
+import com.tgyuu.designsystem.component.EbbingDialog
+import com.tgyuu.designsystem.component.EbbingDialogBottom
+import com.tgyuu.designsystem.component.EbbingDialogDefaultTop
+import com.tgyuu.designsystem.component.EbbingSolidButton
+import com.tgyuu.designsystem.component.EbbingSubTopBar
+import com.tgyuu.designsystem.component.EbbingTextInputDefault
+import com.tgyuu.designsystem.foundation.EbbingTheme
+import com.tgyuu.sync.graph.restore.contract.RestoreIntent
+import com.tgyuu.sync.graph.restore.contract.RestoreState
+
+@Composable
+internal fun RestoreByDeviceIdRoute(
+    viewModel: RestoreViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    RestoreScreen(
+        state = state,
+        onBackClick = { viewModel.onIntent(RestoreIntent.OnBackClick) },
+        onDeviceIdChange = { viewModel.onIntent(RestoreIntent.OnDeviceIdChange(it)) },
+        onRestoreClick = { viewModel.onIntent(RestoreIntent.OnRestoreClick) },
+    )
+}
+
+@Composable
+private fun RestoreScreen(
+    state: RestoreState,
+    onBackClick: () -> Unit,
+    onDeviceIdChange: (String) -> Unit,
+    onRestoreClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+    var isShowConfirmDialog by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = state.isRestoring) {}
+
+    if (isShowConfirmDialog) {
+        ConfirmRestoreDialog(
+            onDismissRequest = { isShowConfirmDialog = false },
+            onRestoreClick = {
+                isShowConfirmDialog = false
+                onRestoreClick()
+                focusManager.clearFocus()
+            },
+        )
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding(),
+        ) {
+            EbbingSubTopBar(
+                title = stringResource(R.string.sync_restore_title),
+                onNavigationClick = { if (!state.isRestoring) onBackClick() },
+                rightComponent = {},
+                modifier = Modifier.padding(horizontal = 20.dp),
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(20.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.sync_restore_headline),
+                    style = EbbingTheme.typography.heading24B,
+                    color = EbbingTheme.colors.textOnBackground,
+                )
+
+                Text(
+                    text = stringResource(R.string.sync_restore_description),
+                    style = EbbingTheme.typography.body14M,
+                    color = EbbingTheme.colors.textSub,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+
+                Text(
+                    text = stringResource(R.string.sync_restore_input_label),
+                    style = EbbingTheme.typography.body16M,
+                    color = EbbingTheme.colors.textOnBackground,
+                    modifier = Modifier.padding(top = 32.dp),
+                )
+
+                EbbingTextInputDefault(
+                    value = state.deviceId,
+                    hint = stringResource(R.string.sync_restore_input_hint),
+                    keyboardType = KeyboardType.Text,
+                    onValueChange = onDeviceIdChange,
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .fillMaxWidth(),
+                )
+            }
+
+            EbbingSolidButton(
+                label = stringResource(R.string.sync_restore_button),
+                onClick = { isShowConfirmDialog = true },
+                enabled = state.isRestoreEnabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+            )
+        }
+
+        if (state.isRestoring) {
+            CircularProgressIndicator(
+                color = EbbingTheme.colors.primaryNormal,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(40.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfirmRestoreDialog(
+    onDismissRequest: () -> Unit,
+    onRestoreClick: () -> Unit,
+) {
+    EbbingDialog(
+        dialogTop = {
+            EbbingDialogDefaultTop(
+                title = stringResource(R.string.sync_restore_confirm_title),
+                subText = stringResource(R.string.sync_restore_confirm_desc),
+            )
+        },
+        dialogBottom = {
+            EbbingDialogBottom(
+                leftButtonText = stringResource(R.string.sync_restore_confirm_cancel),
+                rightButtonText = stringResource(R.string.sync_restore_button),
+                onLeftButtonClick = onDismissRequest,
+                onRightButtonClick = onRestoreClick,
+            )
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+@EbbingPreview
+@Composable
+private fun PreviewRestoreScreen() {
+    BasePreview {
+        RestoreScreen(
+            state = RestoreState(deviceId = "3f2a8b1c"),
+            onBackClick = {},
+            onDeviceIdChange = {},
+            onRestoreClick = {},
+        )
+    }
+}

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreViewModel.kt
@@ -1,0 +1,112 @@
+package com.tgyuu.sync.graph.restore
+
+import com.tgyuu.analytics.AnalyticsEvent
+import com.tgyuu.analytics.AnalyticsHelper
+import com.tgyuu.common.base.BaseViewModel
+import com.tgyuu.common.event.EbbingEvent
+import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.isNetworkError
+import com.tgyuu.common.suspendRunCatching
+import com.tgyuu.common.ui.resource.ResourceProvider
+import com.tgyuu.designsystem.R
+import com.tgyuu.domain.model.ErrorBus
+import com.tgyuu.domain.model.sync.RestoreResult
+import com.tgyuu.domain.repository.SyncRepository
+import com.tgyuu.navigation.NavigationBus
+import com.tgyuu.navigation.NavigationEvent
+import com.tgyuu.sync.graph.restore.contract.RestoreIntent
+import com.tgyuu.sync.graph.restore.contract.RestoreState
+import com.tgyuu.sync.network.NetworkMonitor
+import com.tgyuu.sync.network.NetworkState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RestoreViewModel @Inject constructor(
+    private val syncRepository: SyncRepository,
+    private val networkMonitor: NetworkMonitor,
+    private val navigationBus: NavigationBus,
+    private val errorBus: ErrorBus,
+    private val eventBus: EventBus,
+    private val analyticsHelper: AnalyticsHelper,
+    private val resourceProvider: ResourceProvider,
+) : BaseViewModel<RestoreState, RestoreIntent>(RestoreState()) {
+
+    init {
+        analyticsHelper.logEvent(AnalyticsEvent.View(screenName = "RestoreByDeviceId"))
+    }
+
+    override suspend fun processIntent(intent: RestoreIntent) {
+        when (intent) {
+            RestoreIntent.OnBackClick -> onBackClick()
+            is RestoreIntent.OnDeviceIdChange -> setState { copy(deviceId = intent.deviceId) }
+            RestoreIntent.OnRestoreClick -> onRestoreClick()
+        }
+    }
+
+    private suspend fun onBackClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = "RestoreByDeviceId", buttonName = "Back")
+        )
+        navigationBus.navigate(NavigationEvent.Up)
+    }
+
+    private suspend fun onRestoreClick() {
+        analyticsHelper.logEvent(
+            AnalyticsEvent.Click(screenName = "RestoreByDeviceId", buttonName = "Restore")
+        )
+
+        if (!currentState.isRestoreEnabled) return
+
+        if (networkMonitor.networkState.value != NetworkState.Connected) {
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_network_required)))
+            return
+        }
+
+        setState { copy(isRestoring = true) }
+
+        val result = suspendRunCatching { syncRepository.restoreByDeviceId(currentState.deviceId) }
+
+        setState { copy(isRestoring = false) }
+
+        result.onSuccess { restoreResult ->
+            when (restoreResult) {
+                is RestoreResult.Success -> {
+                    eventBus.sendEvent(
+                        EbbingEvent.ShowSnackBar(
+                            resourceProvider.getString(
+                                R.string.sync_restore_done,
+                                restoreResult.deviceName,
+                            )
+                        )
+                    )
+                    navigationBus.navigate(NavigationEvent.Up)
+                }
+
+                RestoreResult.NotFound -> eventBus.sendEvent(
+                    EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_not_found))
+                )
+
+                RestoreResult.EmptyData -> eventBus.sendEvent(
+                    EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_empty_data))
+                )
+
+                RestoreResult.Ambiguous -> eventBus.sendEvent(
+                    EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_ambiguous))
+                )
+
+                RestoreResult.SelfDevice -> eventBus.sendEvent(
+                    EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_self))
+                )
+            }
+        }.onFailure { exception ->
+            errorBus.sendError(exception)
+            val message = if (exception.isNetworkError()) {
+                resourceProvider.getString(R.string.sync_network_check)
+            } else {
+                resourceProvider.getString(R.string.sync_restore_failed)
+            }
+            eventBus.sendEvent(EbbingEvent.ShowSnackBar(message))
+        }
+    }
+}

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/contract/RestoreIntent.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/contract/RestoreIntent.kt
@@ -1,0 +1,9 @@
+package com.tgyuu.sync.graph.restore.contract
+
+import com.tgyuu.common.base.UiIntent
+
+sealed class RestoreIntent : UiIntent {
+    data object OnBackClick : RestoreIntent()
+    data class OnDeviceIdChange(val deviceId: String) : RestoreIntent()
+    data object OnRestoreClick : RestoreIntent()
+}

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/contract/RestoreState.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/contract/RestoreState.kt
@@ -1,0 +1,13 @@
+package com.tgyuu.sync.graph.restore.contract
+
+import androidx.compose.runtime.Immutable
+import com.tgyuu.common.base.UiState
+
+@Immutable
+data class RestoreState(
+    val deviceId: String = "",
+    val isRestoring: Boolean = false,
+) : UiState {
+    val isRestoreEnabled: Boolean
+        get() = deviceId.isNotBlank() && !isRestoring
+}

--- a/feature/sync/src/main/java/com/tgyuu/sync/navigation/SyncNavigation.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/navigation/SyncNavigation.kt
@@ -6,11 +6,16 @@ import androidx.navigation.navigation
 import com.tgyuu.navigation.SyncBaseRoute
 import com.tgyuu.navigation.SyncGraph
 import com.tgyuu.sync.graph.main.SyncMainRoute
+import com.tgyuu.sync.graph.restore.RestoreByDeviceIdRoute
 
 fun NavGraphBuilder.syncNavigation() {
     navigation<SyncBaseRoute>(startDestination = SyncGraph.SyncMainRoute) {
         composable<SyncGraph.SyncMainRoute> {
             SyncMainRoute()
+        }
+
+        composable<SyncGraph.RestoreByDeviceIdRoute> {
+            RestoreByDeviceIdRoute()
         }
     }
 }


### PR DESCRIPTION
QR 연동 없이 deviceId(UUID 앞 8자리)만으로 다른 기기가 백업한 데이터를
현재 기기로 복원한다. 설정 > 데이터 > 자동 백업 아래 진입점 추가.

- 복원 화면(feature/sync/graph/restore): deviceId 입력 → 확인 다이얼로그 → 복원. 바텀 네비 숨김, 네트워크 배너 대상, 성공 시 설정 이동 + 스낵바
- network/domain: sync_info prefix 조회(ilike), restoreByDeviceId — 입력 정규화('기기명 · 8자리' 붙여넣기 대응), 자기기기/미존재/중복/빈데이터 분기(RestoreResult). 복원은 다운로드 전용(동기화 상태 변경 없음)
- 안전장치: 대상 uuid 에 실질 데이터 없으면 로컬 보존 + 안내, replaceAllData 고아 행 필터링(FOREIGN KEY 크래시 수정, QR 연동 공용)
- 화면 이동과 함께 띄운 스낵바가 즉시 닫히던 공통 버그 수정
- 문자열 ko/en/ja, 실패 시 errorBus 로깅

## 1. ⭐️ 변경된 내용 

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 기기 ID로 동기화 데이터를 복원하는 화면과 흐름이 추가되었습니다.
  * 설정 화면에 데이터 복원 항목이 새로 생겼습니다.
  * 복원 결과에 따라 성공/미발견/빈 데이터/모호함/현재 기기 등 다양한 안내가 표시됩니다.

* **Bug Fixes**
  * 복원 중 스낵바가 네비게이션과 함께 즉시 닫히도록 개선되었습니다.
  * 복원 시 데이터 저장 과정에서 일부 데이터가 잘못 연결되는 문제를 방지하도록 처리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->