### PR TITLE
fix(sync): 기기 연동 중 deviceId 복원 차단

### DIFF
--- a/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/SyncRepositoryImpl.kt
@@ -130,6 +130,8 @@ class SyncRepositoryImpl @Inject constructor(
     }
 
     override suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult {
+        if (getConnectedUuid() != null) return RestoreResult.LinkedDevice
+
         val prefix = deviceIdPrefix.trim()
             .substringAfterLast('·')
             .substringAfterLast(' ')

--- a/core/designsystem/src/main/res/values-en/strings.xml
+++ b/core/designsystem/src/main/res/values-en/strings.xml
@@ -51,6 +51,7 @@
     <string name="sync_restore_empty_data">That device\'s backup is empty. If it was linked to another device, try that device\'s deviceId instead.</string>
     <string name="sync_restore_ambiguous">Multiple devices match. Please check the deviceId again.</string>
     <string name="sync_restore_self">That\'s this device\'s deviceId. Please enter another device\'s deviceId.</string>
+    <string name="sync_restore_linked">You can\'t restore while linked to another device. Unlink and try again.</string>
     <string name="sync_restore_failed">Restore failed. Please try again later.</string>
     <string name="sync_restore_confirm_title">Restore data?</string>
     <string name="sync_restore_confirm_desc">All data on this device will be replaced and cannot be undone.</string>

--- a/core/designsystem/src/main/res/values-ja/strings.xml
+++ b/core/designsystem/src/main/res/values-ja/strings.xml
@@ -51,6 +51,7 @@
     <string name="sync_restore_empty_data">その端末のバックアップは空です。他の端末と連携していた場合は、連携先端末のdeviceIdでお試しください。</string>
     <string name="sync_restore_ambiguous">一致する端末が複数あります。deviceIdをもう一度確認してください。</string>
     <string name="sync_restore_self">この端末のdeviceIdです。他の端末のdeviceIdを入力してください。</string>
+    <string name="sync_restore_linked">端末連携中は復元できません。連携を解除してから再度お試しください。</string>
     <string name="sync_restore_failed">復元に失敗しました。しばらくしてから再度お試しください。</string>
     <string name="sync_restore_confirm_title">データを復元しますか？</string>
     <string name="sync_restore_confirm_desc">この端末のデータはすべて置き換えられ、元に戻せません。</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="sync_restore_empty_data">해당 기기의 백업 데이터가 비어 있어요. 다른 기기와 연동해 사용했다면, 연동했던 기기의 deviceId로 시도해 주세요.</string>
     <string name="sync_restore_ambiguous">일치하는 기기가 여러 개예요. deviceId를 다시 확인해 주세요.</string>
     <string name="sync_restore_self">현재 기기의 deviceId예요. 다른 기기의 deviceId를 입력해 주세요.</string>
+    <string name="sync_restore_linked">기기 연동 중에는 복원할 수 없어요. 연동 해제 후 다시 시도해 주세요.</string>
     <string name="sync_restore_failed">복원에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="sync_restore_confirm_title">데이터를 복원할까요?</string>
     <string name="sync_restore_confirm_desc">현재 기기의 데이터가 모두 교체되며, 되돌릴 수 없어요.</string>

--- a/core/domain/src/main/java/com/tgyuu/domain/model/sync/RestoreResult.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/model/sync/RestoreResult.kt
@@ -6,4 +6,5 @@ sealed interface RestoreResult {
     data object EmptyData : RestoreResult
     data object Ambiguous : RestoreResult
     data object SelfDevice : RestoreResult
+    data object LinkedDevice : RestoreResult
 }

--- a/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreViewModel.kt
+++ b/feature/sync/src/main/java/com/tgyuu/sync/graph/restore/RestoreViewModel.kt
@@ -98,6 +98,10 @@ class RestoreViewModel @Inject constructor(
                 RestoreResult.SelfDevice -> eventBus.sendEvent(
                     EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_self))
                 )
+
+                RestoreResult.LinkedDevice -> eventBus.sendEvent(
+                    EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.sync_restore_linked))
+                )
             }
         }.onFailure { exception ->
             errorBus.sendError(exception)


### PR DESCRIPTION
연동된 상태에서 복원하면 다음 동기화 때 연동 상대의 증분 데이터가
복원본 위에 병합되고, 업로드도 연동 uuid 로 나가 공유 데이터셋이
오염될 수 있음. 연동 중이면 RestoreResult.LinkedDevice 를 반환하고 '연동 해제 후 다시 시도' 스낵바(ko/en/ja)로 안내.

## 1. ⭐️ 변경된 내용 

## 2. 🖼️ 스크린샷(선택)

## 3. 💡 알게된 부분

## 4. 📌 이 부분은 꼭 봐주세요!