### PR TITLE
fix(sync): 업로드 시 uploaded_at을 명시해 증분 동기화 누락 수정

### DIFF
--- a/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/SupabaseSyncDataSource.kt
@@ -64,10 +64,15 @@ class SupabaseSyncDataSource @Inject constructor(
                 .upsert(SyncInfoDto(uuid = uuid, deviceName = deviceName))
         }
 
-        val scheduleDtos = schedules.map { it.toDto(uuid) }
-        val infoDtos = infos.map { it.toDto(uuid) }
-        val repeatCycleDtos = repeatCycles.map { it.toDto(uuid) }
-        val tagDtos = tags.map { it.toDto(uuid) }
+        // upsert 업데이트 시 DB가 uploaded_at을 갱신해주지 않으므로 클라이언트가 직접 찍어준다.
+        // (증분 다운로드가 uploaded_at > lastSyncTime 필터를 사용)
+        val now = ZonedDateTime.now()
+        val uploadedAtIso = now.format(ISO_FORMAT)
+
+        val scheduleDtos = schedules.map { it.toDto(uuid).copy(uploadedAt = uploadedAtIso) }
+        val infoDtos = infos.map { it.toDto(uuid).copy(uploadedAt = uploadedAtIso) }
+        val repeatCycleDtos = repeatCycles.map { it.toDto(uuid).copy(uploadedAt = uploadedAtIso) }
+        val tagDtos = tags.map { it.toDto(uuid).copy(uploadedAt = uploadedAtIso) }
 
         val failures = mutableListOf<Throwable>()
 
@@ -97,7 +102,6 @@ class SupabaseSyncDataSource @Inject constructor(
 
         if (failures.isNotEmpty()) throw failures.first()
 
-        val now = ZonedDateTime.now()
         supabase.from(TABLE_SYNC_INFO)
             .update({
                 set("last_updated_at", now.format(ISO_FORMAT))

--- a/feature/sync/src/test/java/com/tgyuu/sync/fake/FakeSyncRepository.kt
+++ b/feature/sync/src/test/java/com/tgyuu/sync/fake/FakeSyncRepository.kt
@@ -3,6 +3,7 @@ package com.tgyuu.sync.fake
 import com.tgyuu.domain.model.sync.ConnectInfo
 import com.tgyuu.domain.model.sync.ConnectResult
 import com.tgyuu.domain.model.sync.ConnectedPeer
+import com.tgyuu.domain.model.sync.RestoreResult
 import com.tgyuu.domain.model.sync.ServerSyncInfo
 import com.tgyuu.domain.repository.SyncRepository
 import java.time.LocalDateTime
@@ -60,6 +61,10 @@ class FakeSyncRepository : SyncRepository {
         if (shouldConnectFail) throw Exception("연동 오류")
         return connectResult
     }
+
+    var restoreResult: RestoreResult = RestoreResult.NotFound
+
+    override suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult = restoreResult
 
     override suspend fun disconnectAnother() {
         connectedUuid = null


### PR DESCRIPTION
## 문제
기기 연동 후 첫 동기화(전체 복원)는 되지만, 연동된 상태에서 수동 동기화 시 상대 기기에 **동기화 시간만 갱신되고 데이터가 반영되지 않는** 문제

## 원인
- 증분 다운로드는 `uploaded_at > lastSyncTime` 필터로 변경분을 가져옴
- Firestore 시절에는 `@ServerTimestamp var uploadedAt`으로 매 업로드마다 서버가 자동 갱신했지만, Supabase 전환 후 클라이언트가 `uploaded_at`을 전송하지 않음
- Postgres upsert는 payload에 없는 컬럼을 업데이트하지 않으므로, **기존 행을 수정해도 `uploaded_at`이 최초 삽입 시각에 머물러** 상대 기기의 증분 다운로드에서 계속 제외됨
- `sync_info.last_updated_at`은 별도로 명시 갱신하고 있어 시간 표시만 최신으로 보였음
- 재연동 시 되는 이유: epoch(1970)부터 전체 복원이라 필터에 걸리지 않음

## 수정
- `uploadData()`에서 4개 테이블(schedules/infos/repeatCycles/tags) DTO에 업로드 시각을 `uploaded_at`으로 명시하여 upsert
- `sync_info.last_updated_at`에 쓰는 `now`와 동일한 값 재사용

## 참고
- 기존에 "고장난 기간"에 수정된 데이터는 `uploaded_at`이 과거라 다시 수정되기 전까지 증분 동기화 대상에서 빠짐 → 재연동(전체 복원) 시 해소
- `FakeSyncRepository`가 #117에서 추가된 `restoreByDeviceId`를 구현하지 않아 테스트 컴파일이 깨져 있던 것도 함께 수정

## 테스트
- 실기기 2대(폰↔태블릿)로 연동 상태에서 수정 → 동기화 → 반영 확인
- `:feature:sync`, `:core:data` 유닛 테스트 통과