### PR TITLE
fix(home): 달력 월/주 전환 스크롤 감지를 리스트에서 헤더 드래그로 변경

### DIFF
--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/ui/EbbingTodoList.kt
@@ -1,5 +1,8 @@
 package com.tgyuu.home.graph.main.ui
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -84,6 +87,17 @@ internal fun EbbingTodoList(
             totalCount = todoLists.size,
             sortType = sortType,
             onSortTypeChange = onSortTypeChange,
+            modifier = if (calendarNestedScroll != null) {
+                Modifier
+                    .nestedScroll(calendarNestedScroll)
+                    // 헤더 드래그를 nested scroll 이벤트로 변환 (델타는 소비하지 않음)
+                    .scrollable(
+                        state = rememberScrollableState { 0f },
+                        orientation = Orientation.Vertical,
+                    )
+            } else {
+                Modifier
+            },
         )
 
         HorizontalPager(state = pagerState) { page ->
@@ -94,7 +108,6 @@ internal fun EbbingTodoList(
                 schedulesByTodoInfo = schedulesByTodoInfo,
                 onCheckedChange = onCheckedChange,
                 onEdit = onEditScheduleClick,
-                calendarNestedScroll = calendarNestedScroll,
             )
         }
     }
@@ -107,10 +120,11 @@ private fun TodoHeader(
     totalCount: Int,
     sortType: SortType,
     onSortTypeChange: (SortType) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 12.dp)
     ) {
@@ -161,7 +175,6 @@ private fun TodoPage(
     schedulesByTodoInfo: Map<Int, List<TodoScheduleUiModel>>,
     onCheckedChange: (TodoScheduleUiModel) -> Unit,
     onEdit: (TodoScheduleUiModel) -> Unit,
-    calendarNestedScroll: NestedScrollConnection? = null,
 ) {
     val listState = rememberLazyListState()
 
@@ -176,13 +189,6 @@ private fun TodoPage(
             verticalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier
                 .fillMaxSize()
-                .then(
-                    if (calendarNestedScroll != null) {
-                        Modifier.nestedScroll(calendarNestedScroll)
-                    } else {
-                        Modifier
-                    }
-                )
                 .padding(horizontal = 20.dp),
         ) {
             if (sortType == SortType.BY_TAG) {


### PR DESCRIPTION
## 변경 사항
- 달력 월/주 전환(접기/펼치기)을 트리거하는 nested scroll 감지 영역을 일정 리스트(`LazyColumn`)에서 **리스트 헤더(날짜 + 정렬 토글 Row)**로 이동
- `TodoHeader`에 `nestedScroll(calendarNestedScroll)` + 델타를 소비하지 않는 `scrollable`(`rememberScrollableState { 0f }`)을 부착해, 스크롤 불가능한 헤더 영역의 드래그를 nested scroll 이벤트로 변환
- `TodoPage`의 `LazyColumn`에 있던 `nestedScroll` 제거 및 `calendarNestedScroll` 파라미터 전달 정리

## 동작 변화
- **헤더 드래그**: 위로 → 주간 접힘 / 아래로 → 월간 펼침
- **일정 리스트 스크롤**: 더 이상 달력이 토글되지 않음 (리스트 스크롤과 달력 상태가 분리됨)

## 테스트
- `:feature:home` 컴파일 확인
- 실기기에서 헤더 드래그 접기/펼치기 및 리스트 스크롤 비간섭 확인 필요