### PR TITLE
fix(home): 화면 이동 후 복귀 시 선택 날짜가 오늘로 초기화되는 문제 수정

### DIFF
--- a/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/main/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -311,11 +312,11 @@ private fun PhoneHomeScreen(
     val analyticsHelper = LocalAnalyticsHelper.current
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
-    var selectedDate by remember(workedDate) { mutableStateOf(workedDate) }
+    var selectedDate by rememberSaveable(workedDate) { mutableStateOf(workedDate) }
     val calendarState = rememberCalendarState()
 
     LaunchedEffect(workedDate) {
-        calendarState.onDateSelect(workedDate)
+        calendarState.onDateSelect(selectedDate)
     }
 
     LaunchedEffect(calendarState.currentDisplayDate.month) {
@@ -473,11 +474,11 @@ private fun TabletHomeScreen(
 ) {
     val analyticsHelper = LocalAnalyticsHelper.current
     val scope = rememberCoroutineScope()
-    var selectedDate by remember(workedDate) { mutableStateOf(workedDate) }
+    var selectedDate by rememberSaveable(workedDate) { mutableStateOf(workedDate) }
     val calendarState = rememberCalendarState()
 
     LaunchedEffect(workedDate) {
-        calendarState.onDateSelect(workedDate)
+        calendarState.onDateSelect(selectedDate)
     }
 
     LaunchedEffect(calendarState.currentDisplayDate.month) {


### PR DESCRIPTION
## 문제
홈에서 다른 날짜를 선택한 뒤 일정 추가 등 다른 화면으로 이동했다가 돌아오면 선택 날짜가 오늘로 되돌아감.

## 원인
- `selectedDate`가 `remember` 로컬 상태라 화면 이동으로 홈 컴포지션이 파괴되면 소실되고, 복귀 시 `workedDate`(오늘)로 재초기화
- `LaunchedEffect(workedDate)`도 복귀 시 재실행되며 캘린더 선택을 오늘로 되돌림

## 수정
- `selectedDate`를 `rememberSaveable`로 변경 (Phone/Tablet 공통) — 백스택 SavedState에 보존되어 복귀 시 복원. `remember(workedDate)` 키는 유지해 위젯 딥링크 등 새 `workedDate` 진입 동작은 그대로
- 초기 캘린더 선택을 `calendarState.onDateSelect(selectedDate)`로 변경 — 첫 진입 시엔 `selectedDate == workedDate`라 동작 동일, 복귀 시엔 복원된 날짜로 캘린더 선택/표시 월 정렬

## 부수 효과
- 프로세스 킬 후 복원 시에도 선택 날짜 유지

## 테스트
- `:feature:home` 컴파일 확인
- 실기기: 날짜 선택 → 일정 추가 화면 이동 → 복귀 시 선택 날짜 유지 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 홈 화면에서 선택한 달력 날짜가 화면을 다시 방문하거나 백스택에서 돌아온 후에도 유지됩니다.
  * 휴대폰과 태블릿 화면에서 저장된 선택 날짜가 올바르게 복원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->