### PR TITLE
chore: AGP 9.2 / Gradle 9.6 / Kotlin 2.3 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,4 +88,5 @@ dependencies {
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.profileinstaller)
     implementation(libs.androidx.adaptive.navigation.suite)
+    implementation(libs.androidx.compose.navigation)
 }

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
@@ -2,6 +2,7 @@ package com.tgyuu.ebbingplanner.backup.fake
 
 import com.tgyuu.domain.model.sync.ConnectResult
 import com.tgyuu.domain.model.sync.ConnectedPeer
+import com.tgyuu.domain.model.sync.RestoreResult
 import com.tgyuu.domain.model.sync.ServerSyncInfo
 import com.tgyuu.domain.repository.SyncRepository
 import java.time.ZonedDateTime
@@ -32,6 +33,8 @@ class FakeSyncRepository : SyncRepository {
     override suspend fun getConnectCodeExpiration(): ZonedDateTime? = null
     override suspend fun connectAnother(connectCode: String): ConnectResult =
         ConnectResult.InvalidOrExpired
+    override suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult =
+        RestoreResult.NotFound
     override suspend fun disconnectAnother() {}
     override suspend fun pollConnectedPeer(): ConnectedPeer? = null
     override suspend fun getStoredPeer(): ConnectedPeer? = null

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,8 +1,5 @@
-import com.android.build.api.dsl.ManagedVirtualDevice
-
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.baselineprofile)
 }
 
@@ -15,10 +12,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = "21"
-    }
-
     defaultConfig {
         minSdk = 28
         targetSdk = 35
@@ -27,12 +20,10 @@ android {
     }
 
     targetProjectPath = ":app"
-    testOptions.managedDevices.devices {
-        create<ManagedVirtualDevice>("pixel6Api35") {
-            device = "Pixel 6"
-            apiLevel = 35
-            systemImageSource = "aosp"
-        }
+    testOptions.managedDevices.localDevices.create("pixel6Api35") {
+        device = "Pixel 6"
+        apiLevel = 35
+        systemImageSource = "aosp"
     }
 }
 

--- a/build-logic/src/main/java/com/tgyuu/build/logic/Extension.kt
+++ b/build-logic/src/main/java/com/tgyuu/build/logic/Extension.kt
@@ -2,20 +2,20 @@ package com.tgyuu.build.logic
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.kotlin.dsl.getByType
 
-internal val Project.applicationExtension: CommonExtension<*, *, *, *, *, *>
+internal val Project.applicationExtension: CommonExtension
     get() = extensions.getByType<ApplicationExtension>()
 
-internal val Project.libraryExtension: CommonExtension<*, *, *, *, *, *>
+internal val Project.libraryExtension: CommonExtension
     get() = extensions.getByType<LibraryExtension>()
 
-internal val Project.androidExtension: CommonExtension<*, *, *, *, *, *>
+internal val Project.androidExtension: CommonExtension
     get() = runCatching { libraryExtension }
         .recoverCatching { applicationExtension }
         .onFailure { println("Could not find Library or Application extension from this project") }

--- a/build-logic/src/main/java/com/tgyuu/build/logic/KotlinAndroid.kt
+++ b/build-logic/src/main/java/com/tgyuu/build/logic/KotlinAndroid.kt
@@ -3,41 +3,32 @@ package com.tgyuu.build.logic
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid() {
-    plugins.apply("org.jetbrains.kotlin.android")
-
     androidExtension.apply {
         compileSdk = 35
 
-        defaultConfig {
-            minSdk = 28
+        defaultConfig.minSdk = 28
+
+        buildTypes.getByName("release").apply {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
 
-        buildTypes {
-            getByName("release") {
-                isMinifyEnabled = false
-                proguardFiles(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro",
-                )
-            }
-        }
-
-        compileOptions {
+        compileOptions.apply {
             sourceCompatibility = JavaVersion.VERSION_21
             targetCompatibility = JavaVersion.VERSION_21
         }
 
-        packaging {
-            resources {
-                excludes += "META-INF/LICENSE.md"
-                excludes += "META-INF/LICENSE-notice.md"
-            }
+        packaging.resources.apply {
+            excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/LICENSE-notice.md"
         }
     }
 
@@ -57,7 +48,7 @@ internal fun Project.configureKotlin() {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)
 
-            val warningsAsErrors: String? by project
+            val warningsAsErrors = project.findProperty("warningsAsErrors") as? String
             allWarningsAsErrors.set(warningsAsErrors.toBoolean())
             freeCompilerArgs.set(
                 freeCompilerArgs.get() + listOf(

--- a/build-logic/src/main/java/com/tgyuu/build/logic/TestAndroid.kt
+++ b/build-logic/src/main/java/com/tgyuu/build/logic/TestAndroid.kt
@@ -11,15 +11,15 @@ internal fun Project.configureTestAndroid() {
 @Suppress("UnstableApiUsage")
 internal fun Project.configureJUnitAndroid() {
     androidExtension.apply {
-        testOptions { unitTests.all { it.useJUnitPlatform() } }
-        defaultConfig { testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
+        testOptions.unitTests.all { it.useJUnitPlatform() }
+        defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
 
-        val libs = extensions.libs
-        dependencies {
-            "androidTestImplementation"(libs.findLibrary("androidx.test.ext").get())
-            "androidTestImplementation"(libs.findLibrary("androidx.runner").get())
-            "androidTestImplementation"(libs.findLibrary("androidx.junit").get())
-            "androidTestImplementation"(libs.findLibrary("coroutines-test").get())
-        }
+    val libs = extensions.libs
+    dependencies {
+        "androidTestImplementation"(libs.findLibrary("androidx.test.ext").get())
+        "androidTestImplementation"(libs.findLibrary("androidx.runner").get())
+        "androidTestImplementation"(libs.findLibrary("androidx.junit").get())
+        "androidTestImplementation"(libs.findLibrary("coroutines-test").get())
     }
 }

--- a/build-logic/src/main/java/com/tgyuu/build/logic/TestKotlin.kt
+++ b/build-logic/src/main/java/com/tgyuu/build/logic/TestKotlin.kt
@@ -12,11 +12,13 @@ internal fun Project.configureTest() {
         "testImplementation"(libs.findLibrary("junit4").get())
         "testImplementation"(libs.findLibrary("junit-jupiter").get())
         "testImplementation"(libs.findLibrary("coroutines-test").get())
+        "testRuntimeOnly"(libs.findLibrary("junit-platform-launcher").get())
     }
 }
 
 internal fun Project.configureJUnit() {
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
+        failOnNoDiscoveredTests.set(false)
     }
 }

--- a/build-logic/src/main/java/com/tgyuu/build/logic/configure/AndroidComposes.kt
+++ b/build-logic/src/main/java/com/tgyuu/build/logic/configure/AndroidComposes.kt
@@ -14,10 +14,6 @@ internal fun Project.configureAndroidCompose() {
     val libs = extensions.libs
 
     androidExtension.apply {
-        composeOptions {
-            kotlinCompilerExtensionVersion = "1.5.15"
-        }
-
         buildFeatures.apply {
             compose = true
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android {
     namespace = "com.tgyuu.database"
 
-    sourceSets { getByName("androidTest").assets.srcDir("$projectDir/schemas") }
+    sourceSets { getByName("androidTest").assets.directories += "schemas" }
 }
 
 room {

--- a/gradle/dependencyGraph.gradle
+++ b/gradle/dependencyGraph.gradle
@@ -1,6 +1,6 @@
 task projectDependencyGraph {
     doLast {
-        def dot = new File(rootProject.buildDir, 'reports/dependency-graph/project.dot')
+        def dot = new File(rootProject.layout.buildDirectory.asFile.get(), 'reports/dependency-graph/project.dot')
         dot.parentFile.mkdirs()
         dot.delete()
 
@@ -45,7 +45,7 @@ task projectDependencyGraph {
             project.configurations.all { config ->
                 config.dependencies
                         .withType(ProjectDependency)
-                        .collect { it.dependencyProject }
+                        .collect { project.project(it.path) }
                         .findAll { it != project } // 👈 자기 자신 제외
                         .each { dependency ->
                             projects.add(project)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ## Android gradle plugin
-androidGradlePlugin = "8.7.3"
+androidGradlePlugin = "9.2.0"
 
 ## AndroidX
 # https://developer.android.com/jetpack/androidx/releases/core
@@ -32,17 +32,17 @@ material = "1.12.0"
 
 ## Kotlin Symbol Processing
 # https://github.com/google/ksp/
-ksp = "2.1.0-1.0.29"
+ksp = "2.3.10"
 
 ## Hilt
 # https://github.com/google/dagger/releases
-hilt = "2.55"
+hilt = "2.60.1"
 # https://developer.android.com/jetpack/androidx/releases/hilt
 hiltCommon = "1.2.0"
 
 ## Kotlin
 # https://github.com/JetBrains/kotlin
-kotlin = "2.1.0"
+kotlin = "2.3.21"
 # https://github.com/Kotlin/kotlinx.serialization
 kotlinxSerializationJson = "1.8.0"
 # https://github.com/Kotlin/kotlinx.coroutines
@@ -56,25 +56,26 @@ gson = "2.12.1"
 # https://github.com/junit-team/junit4
 junit4 = "4.13.2"
 junitJupiter = "5.8.2"
+junitPlatformLauncher = "1.8.2"
 # https://mockk.io/
 mockk = "1.13.11"
 # https://github.com/pinterest/ktlint
-ktlint = "12.1.1"
+ktlint = "14.2.0"
 # https://developer.android.com/jetpack/androidx/releases/test
 androidxTestRunner = "1.6.2"
 androidxTestExt = "1.2.1"
 androidxEspresso = "3.6.1"
 
 ## BenchMark
-benchmarkMacroJunit4 = "1.3.3"
-baselineprofile = "1.3.3"
+benchmarkMacroJunit4 = "1.5.0-alpha07"
+baselineprofile = "1.5.0-alpha07"
 profileinstaller = "1.4.1"
 uiautomator = "2.3.0"
 
 ## firebase
-googleServices = "4.4.2"
+googleServices = "4.5.0"
 firebaseBom = "33.10.0"
-crashlytics = "3.0.3"
+crashlytics = "3.0.7"
 metricsPerformance = "1.0.0-beta02"
 
 ## Amplitude
@@ -167,6 +168,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatformLauncher" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }
@@ -205,7 +207,6 @@ ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "k
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 11 14:20:55 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 배경

Play Console에 "R8 최적화로 앱의 메모리 및 성능 개선" 권고가 표시됨 (호환성 모드 사용, 최적화/난독화/축소 미사용 등).

실제 확인 결과 앱은 이미 R8 full mode + 전체 최적화로 빌드되고 있었으나, AGP 8.7이 AAB의 `BUNDLE-METADATA/com.android.tools/r8.json`에 버전 정보만 기록해서 Play Console이 최적화 상태를 읽지 못하는 것이 원인. AGP 9부터 전체 플래그가 기록됨.

## 변경 사항

### 버전 업그레이드
- AGP 8.7.3 → **9.0.1**, Gradle 8.11.1 → **9.1.0**
- Kotlin 2.1.0 → **2.3.21** — AGP built-in Kotlin 전환, `kotlin-android` 플러그인 제거
- KSP 2.1.0-1.0.29 → **2.3.10** (Kotlin 버전 독립 체계)
- Hilt 2.55 → **2.60.1** (AGP 9 지원은 2.59+)
- crashlytics 3.0.7 / google-services 4.5.0 / ktlint 14.2.0
- baselineprofile·benchmark 1.5.0-alpha07 (1.4.1은 AGP 9 미지원)

### AGP 9 새 DSL 대응 (build-logic)
- DSL 블록 함수가 인터페이스에서 제거되어 프로퍼티 접근으로 변경 (`defaultConfig { }` → `defaultConfig.minSdk = ...`)
- `composeOptions` 제거 (Kotlin 2.x compose 플러그인에선 불필요)
- `CommonExtension`이 ExtensionAware가 되면서 apply 블록 안 `extensions.libs`가 android 확장으로 해석되던 문제 수정
- `ManagedDevices.devices` → `localDevices`
- `com.android.build.gradle.LibraryExtension` → `com.android.build.api.dsl.LibraryExtension`

### 동작 변화 대응
- **AGP 9부터 라이브러리 모듈의 dependency constraint가 소비자에 전파되지 않음** → app의 navigation-compose가 2.5.1(hilt-navigation-compose 전이 의존성)로 다운그레이드되어 컴파일 실패 → app에 명시 선언
- AGP 9부터 `consumerProguardFiles`에 선언된 파일이 없으면 에러 → `core:experiment:data`에 빈 consumer-rules.pro 추가
- Gradle 9부터 `junit-platform-launcher`를 테스트 런타임에 명시해야 함
- Gradle 9부터 테스트 소스는 있지만 발견된 테스트가 0개면 실패 처리 → `failOnNoDiscoveredTests=false` (feature:sync는 Fake만 존재)
- `dependencyGraph.gradle`의 삭제된 API 교체 (`buildDir`, `dependencyProject`)

### 기타
- develop에서 이미 깨져 있던 `FakeSyncRepository` 테스트 컴파일 에러 수정 (인터페이스에 `restoreByDeviceId` 추가 시 Fake 누락) — 별도 커밋

## 검증

- ✅ assembleDebug
- ✅ :app:bundleRelease — 새 AAB의 r8.json에 full mode·난독화·최적화·축소·리소스 축소 플래그 기록 확인, dex 마커 `r8-mode: full`
- ✅ testDebugUnitTest 전체 통과
- ✅ :baselineprofile:assembleBenchmarkRelease

## 주의

- **Android Studio Otter 3 Feature Drop (2025.2.3) 이상 필요** — 이하 버전에선 프로젝트 열기 불가
- Kotlin/Hilt 메이저 업그레이드이므로 릴리즈 빌드 기기 스모크 테스트 권장
- 다음 릴리즈 업로드 후 Play Console 경고 해소 확인 (분석에 며칠 소요될 수 있음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Compose Navigation 지원이 추가되었습니다.
  * 테스트 실행 환경이 개선되어 JUnit Platform 기반 테스트를 안정적으로 실행할 수 있습니다.
  * Android 및 Compose 빌드 설정이 최신 Gradle 환경에 맞게 정비되었습니다.

* **업데이트**
  * Android 빌드 도구, Kotlin, 테스트 및 관련 라이브러리 버전이 업데이트되었습니다.
  * Gradle Wrapper가 최신 버전으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->