### PR TITLE
[Feat] : 일정 저장 시 태그·반복 주기를 기억해 최근 사용순으로 표시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ migration/
 *.apk
 *.aab
 app/release/
+
+# iOS 로컬 작업 (안드로이드 레포에 커밋하지 않음)
+iosApp/

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeConfigRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeConfigRepository.kt
@@ -51,4 +51,8 @@ class FakeConfigRepository : ConfigRepository {
     override fun getCalendarDefaultView(): Flow<CalendarDefaultView> =
         flowOf(CalendarDefaultView.MONTHLY)
     override suspend fun setCalendarDefaultView(view: CalendarDefaultView) {}
+    override suspend fun getTagUsageOrder(): List<Int> = emptyList()
+    override suspend fun recordTagUsage(tagId: Int) {}
+    override suspend fun getRepeatCycleUsageOrder(): List<Int> = emptyList()
+    override suspend fun recordRepeatCycleUsage(cycleId: Int) {}
 }

--- a/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
+++ b/app/src/test/java/com/tgyuu/ebbingplanner/backup/fake/FakeSyncRepository.kt
@@ -2,6 +2,7 @@ package com.tgyuu.ebbingplanner.backup.fake
 
 import com.tgyuu.domain.model.sync.ConnectResult
 import com.tgyuu.domain.model.sync.ConnectedPeer
+import com.tgyuu.domain.model.sync.RestoreResult
 import com.tgyuu.domain.model.sync.ServerSyncInfo
 import com.tgyuu.domain.repository.SyncRepository
 import java.time.ZonedDateTime
@@ -18,6 +19,8 @@ class FakeSyncRepository : SyncRepository {
     override suspend fun getServerLastUpdatedAt(): ServerSyncInfo? =
         serverLastUpdatedAt?.let { ServerSyncInfo(lastUpdatedAt = it, connectedDeviceName = "") }
     override suspend fun getLocalSyncedAt(): ZonedDateTime? = null
+    override suspend fun restoreByDeviceId(deviceIdPrefix: String): RestoreResult =
+        RestoreResult.NotFound
 
     override suspend fun syncUpData(): ZonedDateTime {
         syncUpCallCount++

--- a/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/ConfigRepositoryImpl.kt
@@ -111,6 +111,18 @@ class ConfigRepositoryImpl @Inject constructor(
     override suspend fun setAutoBackupEnabled(enabled: Boolean) =
         localUserConfigDataSource.setAutoBackupEnabled(enabled)
 
+    override suspend fun getTagUsageOrder(): List<Int> =
+        localUserConfigDataSource.tagUsageOrder.first()
+
+    override suspend fun recordTagUsage(tagId: Int) =
+        localUserConfigDataSource.recordTagUsage(tagId)
+
+    override suspend fun getRepeatCycleUsageOrder(): List<Int> =
+        localUserConfigDataSource.repeatCycleUsageOrder.first()
+
+    override suspend fun recordRepeatCycleUsage(cycleId: Int) =
+        localUserConfigDataSource.recordRepeatCycleUsage(cycleId)
+
     private suspend fun logNotificationConfigSilently() = runCatching {
         val uuid = localSyncDataSource.uuid.first()
         val enabled = localUserConfigDataSource.notificationEnabled.first()

--- a/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
@@ -182,10 +182,12 @@ class TodoRepositoryImpl @Inject constructor(
         val todoJob = launch { localTodoDataSource.softDeleteAllTodos() }
         val todoInfoJob = launch { localTodoDataSource.deleteAllTodoInfos() }
         val repeatCycleJob = launch { localRepeatCycleDataSource.softDeleteAllRepeatCycles() }
+        val usageOrderJob = launch { localUserConfigDataSource.clearUsageOrder() }
 
         tagJob.join()
         todoJob.join()
         todoInfoJob.join()
         repeatCycleJob.join()
+        usageOrderJob.join()
     }
 }

--- a/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/TodoRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.tgyuu.database.model.TodoTagEntity
 import com.tgyuu.database.source.repeatcycle.LocalRepeatCycleDataSource
 import com.tgyuu.database.source.tag.LocalTagDataSource
 import com.tgyuu.database.source.todo.LocalTodoDataSource
+import com.tgyuu.datastore.datasource.user.LocalUserConfigDataSource
 import com.tgyuu.domain.model.DefaultTodoTag
 import com.tgyuu.domain.model.RepeatCycle
 import com.tgyuu.domain.model.TodoInfo
@@ -21,6 +22,7 @@ class TodoRepositoryImpl @Inject constructor(
     private val localTagDataSource: LocalTagDataSource,
     private val localTodoDataSource: LocalTodoDataSource,
     private val localRepeatCycleDataSource: LocalRepeatCycleDataSource,
+    private val localUserConfigDataSource: LocalUserConfigDataSource,
 ) : TodoRepository {
     private var _recentAddedTagId: Long? = null
     override val recentAddedTagId: Long?
@@ -119,8 +121,10 @@ class TodoRepositoryImpl @Inject constructor(
     override suspend fun updateRepeatCycle(repeatCycle: RepeatCycle) =
         localRepeatCycleDataSource.updateRepeatCycle(repeatCycle)
 
-    override suspend fun deleteRepeatCycle(repeatCycle: RepeatCycle) =
+    override suspend fun deleteRepeatCycle(repeatCycle: RepeatCycle) {
         localRepeatCycleDataSource.softDeleteRepeatCycle(repeatCycle)
+        localUserConfigDataSource.removeRepeatCycleUsage(repeatCycle.id)
+    }
 
     override suspend fun loadSchedule(id: Int): TodoSchedule? =
         localTodoDataSource.getTodoSchedule(id)
@@ -168,7 +172,10 @@ class TodoRepositoryImpl @Inject constructor(
         localTodoDataSource.softDeleteTodoByTodoInfo(id)
 
     override suspend fun updateTag(todoTag: TodoTag) = localTagDataSource.updateTag(todoTag)
-    override suspend fun deleteTag(todoTag: TodoTag) = localTagDataSource.softDeleteTag(todoTag)
+    override suspend fun deleteTag(todoTag: TodoTag) {
+        localTagDataSource.softDeleteTag(todoTag)
+        localUserConfigDataSource.removeTagUsage(todoTag.id)
+    }
 
     override suspend fun clearData() = coroutineScope {
         val tagJob = launch { localTagDataSource.softDeleteAllTags() }

--- a/core/data/src/test/java/com/tgyuu/data/repository/TodoRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/tgyuu/data/repository/TodoRepositoryImplTest.kt
@@ -1,0 +1,62 @@
+package com.tgyuu.data.repository
+
+import com.tgyuu.database.source.repeatcycle.LocalRepeatCycleDataSource
+import com.tgyuu.database.source.tag.LocalTagDataSource
+import com.tgyuu.database.source.todo.LocalTodoDataSource
+import com.tgyuu.datastore.datasource.user.LocalUserConfigDataSource
+import com.tgyuu.domain.model.RepeatCycle
+import com.tgyuu.domain.model.TodoTag
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TodoRepositoryImplTest {
+    private val localTagDataSource = mockk<LocalTagDataSource>(relaxed = true)
+    private val localTodoDataSource = mockk<LocalTodoDataSource>(relaxed = true)
+    private val localRepeatCycleDataSource = mockk<LocalRepeatCycleDataSource>(relaxed = true)
+    private val localUserConfigDataSource = mockk<LocalUserConfigDataSource>(relaxed = true)
+
+    private lateinit var repository: TodoRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        repository = TodoRepositoryImpl(
+            localTagDataSource = localTagDataSource,
+            localTodoDataSource = localTodoDataSource,
+            localRepeatCycleDataSource = localRepeatCycleDataSource,
+            localUserConfigDataSource = localUserConfigDataSource,
+        )
+    }
+
+    @Test
+    fun `전체 초기화 시 최근 사용 이력도 함께 비운다`() = runTest {
+        repository.clearData()
+
+        coVerify(exactly = 1) { localUserConfigDataSource.clearUsageOrder() }
+    }
+
+    @Test
+    fun `태그 삭제 시 해당 태그를 최근 사용 이력에서 제거한다`() = runTest {
+        val tag = TodoTag(id = 5, name = "T", color = 0, createdAt = LocalDate.now())
+
+        repository.deleteTag(tag)
+
+        coVerify(exactly = 1) { localTagDataSource.softDeleteTag(tag) }
+        coVerify(exactly = 1) { localUserConfigDataSource.removeTagUsage(5) }
+    }
+
+    @Test
+    fun `반복 주기 삭제 시 해당 주기를 최근 사용 이력에서 제거한다`() = runTest {
+        val repeatCycle = RepeatCycle(id = -2, intervals = listOf(0, 1, 7))
+
+        repository.deleteRepeatCycle(repeatCycle)
+
+        coVerify(exactly = 1) { localRepeatCycleDataSource.softDeleteRepeatCycle(repeatCycle) }
+        coVerify(exactly = 1) { localUserConfigDataSource.removeRepeatCycleUsage(-2) }
+    }
+}

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
@@ -35,4 +35,8 @@ interface LocalUserConfigDataSource {
     suspend fun setCalendarDefaultView(view: CalendarDefaultView)
     val autoBackupEnabled: Flow<Boolean>
     suspend fun setAutoBackupEnabled(enabled: Boolean)
+    val tagUsageOrder: Flow<List<Int>>
+    suspend fun recordTagUsage(tagId: Int)
+    val repeatCycleUsageOrder: Flow<List<Int>>
+    suspend fun recordRepeatCycleUsage(cycleId: Int)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
@@ -37,6 +37,8 @@ interface LocalUserConfigDataSource {
     suspend fun setAutoBackupEnabled(enabled: Boolean)
     val tagUsageOrder: Flow<List<Int>>
     suspend fun recordTagUsage(tagId: Int)
+    suspend fun removeTagUsage(tagId: Int)
     val repeatCycleUsageOrder: Flow<List<Int>>
     suspend fun recordRepeatCycleUsage(cycleId: Int)
+    suspend fun removeRepeatCycleUsage(cycleId: Int)
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSource.kt
@@ -41,4 +41,5 @@ interface LocalUserConfigDataSource {
     val repeatCycleUsageOrder: Flow<List<Int>>
     suspend fun recordRepeatCycleUsage(cycleId: Int)
     suspend fun removeRepeatCycleUsage(cycleId: Int)
+    suspend fun clearUsageOrder()
 }

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
@@ -187,6 +187,14 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         }
     }
 
+    /** 전체 초기화 시 태그·반복 주기 최근 사용순을 모두 비운다. */
+    override suspend fun clearUsageOrder() {
+        dataStore.edit { prefs ->
+            prefs.remove(TAG_USAGE_ORDER)
+            prefs.remove(REPEAT_CYCLE_USAGE_ORDER)
+        }
+    }
+
     override suspend fun consumeInAppReview(): Boolean {
         var shouldShow = false
         dataStore.edit { prefs ->

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
@@ -152,6 +152,27 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         dataStore.edit { prefs -> prefs[AUTO_BACKUP_ENABLED] = enabled }
     }
 
+    override val tagUsageOrder: Flow<List<Int>>
+        get() = dataStore.data.map { prefs -> prefs[TAG_USAGE_ORDER].toIdList() }
+
+    override suspend fun recordTagUsage(tagId: Int) {
+        dataStore.edit { prefs ->
+            val newOrder = listOf(tagId) + prefs[TAG_USAGE_ORDER].toIdList().filter { it != tagId }
+            prefs[TAG_USAGE_ORDER] = newOrder.joinToString(",")
+        }
+    }
+
+    override val repeatCycleUsageOrder: Flow<List<Int>>
+        get() = dataStore.data.map { prefs -> prefs[REPEAT_CYCLE_USAGE_ORDER].toIdList() }
+
+    override suspend fun recordRepeatCycleUsage(cycleId: Int) {
+        dataStore.edit { prefs ->
+            val newOrder =
+                listOf(cycleId) + prefs[REPEAT_CYCLE_USAGE_ORDER].toIdList().filter { it != cycleId }
+            prefs[REPEAT_CYCLE_USAGE_ORDER] = newOrder.joinToString(",")
+        }
+    }
+
     override suspend fun consumeInAppReview(): Boolean {
         var shouldShow = false
         dataStore.edit { prefs ->
@@ -201,5 +222,10 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
         private val MONDAY_START = booleanPreferencesKey("MONDAY_START")
         private val CALENDAR_DEFAULT_VIEW = stringPreferencesKey("CALENDAR_DEFAULT_VIEW")
         private val AUTO_BACKUP_ENABLED = booleanPreferencesKey("AUTO_BACKUP_ENABLED")
+        private val TAG_USAGE_ORDER = stringPreferencesKey("TAG_USAGE_ORDER")
+        private val REPEAT_CYCLE_USAGE_ORDER = stringPreferencesKey("REPEAT_CYCLE_USAGE_ORDER")
     }
 }
+
+private fun String?.toIdList(): List<Int> =
+    this?.split(",")?.mapNotNull { it.trim().toIntOrNull() } ?: emptyList()

--- a/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/tgyuu/datastore/datasource/user/LocalUserConfigDataSourceImpl.kt
@@ -153,23 +153,37 @@ class LocalUserConfigDataSourceImpl @Inject constructor(
     }
 
     override val tagUsageOrder: Flow<List<Int>>
-        get() = dataStore.data.map { prefs -> prefs[TAG_USAGE_ORDER].toIdList() }
+        get() = usageOrderFlow(TAG_USAGE_ORDER)
 
-    override suspend fun recordTagUsage(tagId: Int) {
+    override suspend fun recordTagUsage(tagId: Int) = recordUsage(TAG_USAGE_ORDER, tagId)
+
+    override suspend fun removeTagUsage(tagId: Int) = removeUsage(TAG_USAGE_ORDER, tagId)
+
+    override val repeatCycleUsageOrder: Flow<List<Int>>
+        get() = usageOrderFlow(REPEAT_CYCLE_USAGE_ORDER)
+
+    override suspend fun recordRepeatCycleUsage(cycleId: Int) =
+        recordUsage(REPEAT_CYCLE_USAGE_ORDER, cycleId)
+
+    override suspend fun removeRepeatCycleUsage(cycleId: Int) =
+        removeUsage(REPEAT_CYCLE_USAGE_ORDER, cycleId)
+
+    private fun usageOrderFlow(key: Preferences.Key<String>): Flow<List<Int>> =
+        dataStore.data.map { prefs -> prefs[key].toIdList() }
+
+    /** 사용한 [id]를 맨 앞으로 옮겨 최근 사용순을 유지한다. */
+    private suspend fun recordUsage(key: Preferences.Key<String>, id: Int) {
         dataStore.edit { prefs ->
-            val newOrder = listOf(tagId) + prefs[TAG_USAGE_ORDER].toIdList().filter { it != tagId }
-            prefs[TAG_USAGE_ORDER] = newOrder.joinToString(",")
+            val newOrder = listOf(id) + prefs[key].toIdList().filter { it != id }
+            prefs[key] = newOrder.joinToString(",")
         }
     }
 
-    override val repeatCycleUsageOrder: Flow<List<Int>>
-        get() = dataStore.data.map { prefs -> prefs[REPEAT_CYCLE_USAGE_ORDER].toIdList() }
-
-    override suspend fun recordRepeatCycleUsage(cycleId: Int) {
+    /** 삭제된 항목의 [id]를 최근 사용순에서 제거해 오펀 id가 남지 않도록 한다. */
+    private suspend fun removeUsage(key: Preferences.Key<String>, id: Int) {
         dataStore.edit { prefs ->
-            val newOrder =
-                listOf(cycleId) + prefs[REPEAT_CYCLE_USAGE_ORDER].toIdList().filter { it != cycleId }
-            prefs[REPEAT_CYCLE_USAGE_ORDER] = newOrder.joinToString(",")
+            val newOrder = prefs[key].toIdList().filter { it != id }
+            prefs[key] = newOrder.joinToString(",")
         }
     }
 

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/ConfigRepository.kt
@@ -40,6 +40,11 @@ interface ConfigRepository {
     fun getAutoBackupEnabled(): Flow<Boolean>
     suspend fun setAutoBackupEnabled(enabled: Boolean)
 
+    suspend fun getTagUsageOrder(): List<Int>
+    suspend fun recordTagUsage(tagId: Int)
+    suspend fun getRepeatCycleUsageOrder(): List<Int>
+    suspend fun recordRepeatCycleUsage(cycleId: Int)
+
     companion object {
         const val DEFAULT_ALARM_MESSAGE: String = "{할일} 을 확인하고, 잊지 말고 복습하세요!"
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -282,8 +282,10 @@ class AddTodoViewModel @Inject constructor(
             restDays = currentState.restDays.toSet(),
         )
 
-        configRepository.recordTagUsage(tag.id)
-        currentState.repeatCycle?.let { configRepository.recordRepeatCycleUsage(it.id) }
+        runCatching {
+            configRepository.recordTagUsage(tag.id)
+            currentState.repeatCycle?.let { configRepository.recordRepeatCycleUsage(it.id) }
+        }
 
         val (hour, minute) = configRepository.getAlarmTime()
         currentState.schedules.forEach { schedule ->
@@ -305,8 +307,8 @@ class AddTodoViewModel @Inject constructor(
             }
         }
 
-        val isFirstTodo = configRepository.markFirstTodoAdded()
-        configRepository.incrementTodoRegisteredCount()
+        val isFirstTodo = runCatching { configRepository.markFirstTodoAdded() }.getOrDefault(false)
+        runCatching { configRepository.incrementTodoRegisteredCount() }
 
         eventBus.sendEvent(EbbingEvent.ShowSnackBar(resourceProvider.getString(R.string.home_snackbar_todo_added)))
         navigationBus.navigate(

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -23,6 +23,7 @@ import com.tgyuu.domain.repository.ConfigRepository.Companion.DEFAULT_ALARM_MESS
 import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.home.graph.addtodo.contract.AddTodoIntent
 import com.tgyuu.home.graph.addtodo.contract.AddTodoState
+import com.tgyuu.home.model.sortedByUsageOrder
 import com.tgyuu.home.model.toUiModel
 import com.tgyuu.home.model.toUiModels
 import com.tgyuu.navigation.HomeGraph.HomeRoute
@@ -72,10 +73,32 @@ class AddTodoViewModel @Inject constructor(
         }
 
         initNotificationState()
+        initLastSelected()
 
         viewModelScope.launch {
             configRepository.getMondayStart()
                 .collect { setState { copy(mondayStart = it) } }
+        }
+    }
+
+    private fun initLastSelected() = viewModelScope.launch {
+        configRepository.getTagUsageOrder().firstOrNull()?.let { tagId ->
+            val tag = todoRepository.loadTag(tagId) ?: return@let
+            val uiTag = tag.toUiModel().let {
+                if (it.id == DefaultTodoTag.id) {
+                    it.copy(name = resourceProvider.getString(R.string.tag_unassigned))
+                } else {
+                    it
+                }
+            }
+            setState { copy(tag = uiTag) }
+        }
+
+        configRepository.getRepeatCycleUsageOrder().firstOrNull()?.let { cycleId ->
+            val repeatCycle = DefaultRepeatCycles.find { it.id == cycleId }
+                ?: todoRepository.loadRepeatCycles().find { it.id == cycleId }
+                ?: return@let
+            setState { copy(repeatCycle = repeatCycle.toUiModel(resourceProvider)) }
         }
     }
 
@@ -120,13 +143,17 @@ class AddTodoViewModel @Inject constructor(
 
     internal fun loadTags() = viewModelScope.launch {
         val loadedTagList = todoRepository.loadTags()
-        setState { copy(tagList = loadedTagList.toUiModels()) }
+        val usageOrder = configRepository.getTagUsageOrder()
+        val sortedTagList = loadedTagList.sortedByUsageOrder(usageOrder) { it.id }
+        setState { copy(tagList = sortedTagList.toUiModels()) }
     }
 
     internal fun loadRepeatCycles() = viewModelScope.launch {
         val loadedRepeatCycleList = todoRepository.loadRepeatCycles()
         val allRepeatCycles = DefaultRepeatCycles + loadedRepeatCycleList
-        setState { copy(repeatCycleList = allRepeatCycles.toUiModels(resourceProvider)) }
+        val usageOrder = configRepository.getRepeatCycleUsageOrder()
+        val sortedRepeatCycles = allRepeatCycles.sortedByUsageOrder(usageOrder) { it.id }
+        setState { copy(repeatCycleList = sortedRepeatCycles.toUiModels(resourceProvider)) }
     }
 
     override suspend fun processIntent(intent: AddTodoIntent) {
@@ -254,6 +281,9 @@ class AddTodoViewModel @Inject constructor(
             isPinned = currentState.isPinned,
             restDays = currentState.restDays.toSet(),
         )
+
+        configRepository.recordTagUsage(tag.id)
+        currentState.repeatCycle?.let { configRepository.recordRepeatCycleUsage(it.id) }
 
         val (hour, minute) = configRepository.getAlarmTime()
         currentState.schedules.forEach { schedule ->

--- a/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/addtodo/AddTodoViewModel.kt
@@ -82,8 +82,10 @@ class AddTodoViewModel @Inject constructor(
     }
 
     private fun initLastSelected() = viewModelScope.launch {
-        configRepository.getTagUsageOrder().firstOrNull()?.let { tagId ->
-            val tag = todoRepository.loadTag(tagId) ?: return@let
+        // 사용 이력에 삭제된 id가 남아 있을 수 있으므로, 아직 존재하는 가장 최근 항목을 선택한다.
+        val lastTag = configRepository.getTagUsageOrder()
+            .firstNotNullOfOrNull { tagId -> todoRepository.loadTag(tagId) }
+        lastTag?.let { tag ->
             val uiTag = tag.toUiModel().let {
                 if (it.id == DefaultTodoTag.id) {
                     it.copy(name = resourceProvider.getString(R.string.tag_unassigned))
@@ -94,11 +96,14 @@ class AddTodoViewModel @Inject constructor(
             setState { copy(tag = uiTag) }
         }
 
-        configRepository.getRepeatCycleUsageOrder().firstOrNull()?.let { cycleId ->
-            val repeatCycle = DefaultRepeatCycles.find { it.id == cycleId }
-                ?: todoRepository.loadRepeatCycles().find { it.id == cycleId }
-                ?: return@let
-            setState { copy(repeatCycle = repeatCycle.toUiModel(resourceProvider)) }
+        val customRepeatCycles = todoRepository.loadRepeatCycles()
+        val lastRepeatCycle = configRepository.getRepeatCycleUsageOrder()
+            .firstNotNullOfOrNull { cycleId ->
+                DefaultRepeatCycles.find { it.id == cycleId }
+                    ?: customRepeatCycles.find { it.id == cycleId }
+            }
+        lastRepeatCycle?.let {
+            setState { copy(repeatCycle = it.toUiModel(resourceProvider)) }
         }
     }
 

--- a/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/editdate/EditDateViewModel.kt
@@ -20,6 +20,7 @@ import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.home.graph.editdate.contract.EditDateIntent
 import com.tgyuu.home.graph.editdate.contract.EditDateState
+import com.tgyuu.home.model.sortedByUsageOrder
 import com.tgyuu.home.model.toUiModel
 import com.tgyuu.home.model.toUiModels
 import com.tgyuu.navigation.HomeGraph.HomeRoute
@@ -98,7 +99,9 @@ class EditDateViewModel @Inject constructor(
     internal fun loadRepeatCycles() = viewModelScope.launch {
         val loadedRepeatCycleList = todoRepository.loadRepeatCycles()
         val allRepeatCycles = DefaultRepeatCycles + loadedRepeatCycleList
-        setState { copy(repeatCycleList = allRepeatCycles.toUiModels(resourceProvider)) }
+        val usageOrder = configRepository.getRepeatCycleUsageOrder()
+        val sortedRepeatCycles = allRepeatCycles.sortedByUsageOrder(usageOrder) { it.id }
+        setState { copy(repeatCycleList = sortedRepeatCycles.toUiModels(resourceProvider)) }
     }
 
     override suspend fun processIntent(intent: EditDateIntent) {
@@ -198,6 +201,10 @@ class EditDateViewModel @Inject constructor(
             isPinned = currentState.isPinned,
             restDays = currentState.restDays.toSet(),
         )
+
+        runCatching {
+            currentState.repeatCycle?.let { configRepository.recordRepeatCycleUsage(it.id) }
+        }
 
         val (hour, minute) = configRepository.getAlarmTime()
         currentState.schedules.forEach { schedule ->

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
@@ -205,7 +205,7 @@ class EditTodoViewModel @Inject constructor(
 
         todoRepository.updateTodo(newSchedule)
         todoRepository.updateTodoInfo(newSchedule, currentState.restDays.toSet())
-        configRepository.recordTagUsage(tag.id)
+        runCatching { configRepository.recordTagUsage(tag.id) }
         val (hour, minute) = configRepository.getAlarmTime()
 
         currentState.originSchedule?.date?.let { originDate ->

--- a/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/graph/edittodo/EditTodoViewModel.kt
@@ -17,6 +17,7 @@ import com.tgyuu.domain.repository.ConfigRepository
 import com.tgyuu.domain.repository.TodoRepository
 import com.tgyuu.home.graph.edittodo.contract.EditTodoIntent
 import com.tgyuu.home.graph.edittodo.contract.EditTodoState
+import com.tgyuu.home.model.sortedByUsageOrder
 import com.tgyuu.home.model.toUiModel
 import com.tgyuu.home.model.toUiModels
 import com.tgyuu.navigation.HomeGraph
@@ -97,7 +98,9 @@ class EditTodoViewModel @Inject constructor(
 
     internal fun loadTags() = viewModelScope.launch {
         val loadedTagList = todoRepository.loadTags()
-        setState { copy(tagList = loadedTagList.toUiModels()) }
+        val usageOrder = configRepository.getTagUsageOrder()
+        val sortedTagList = loadedTagList.sortedByUsageOrder(usageOrder) { it.id }
+        setState { copy(tagList = sortedTagList.toUiModels()) }
     }
 
     internal fun loadNewTag() {
@@ -202,6 +205,7 @@ class EditTodoViewModel @Inject constructor(
 
         todoRepository.updateTodo(newSchedule)
         todoRepository.updateTodoInfo(newSchedule, currentState.restDays.toSet())
+        configRepository.recordTagUsage(tag.id)
         val (hour, minute) = configRepository.getAlarmTime()
 
         currentState.originSchedule?.date?.let { originDate ->

--- a/feature/home/src/main/java/com/tgyuu/home/model/UsageSort.kt
+++ b/feature/home/src/main/java/com/tgyuu/home/model/UsageSort.kt
@@ -1,0 +1,10 @@
+package com.tgyuu.home.model
+
+/**
+ * 최근 사용 이력([usageOrder], 최근에 사용한 id가 앞) 순으로 목록을 재정렬한다.
+ * 이력에 없는 항목은 기존 순서를 유지한 채 뒤로 배치된다.
+ */
+fun <T> List<T>.sortedByUsageOrder(usageOrder: List<Int>, idSelector: (T) -> Int): List<T> {
+    val rank = usageOrder.withIndex().associate { (index, id) -> id to index }
+    return sortedBy { rank[idSelector(it)] ?: Int.MAX_VALUE }
+}

--- a/feature/home/src/test/java/com/tgyuu/home/fake/FakeConfigRepository.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/fake/FakeConfigRepository.kt
@@ -105,4 +105,19 @@ class FakeConfigRepository : ConfigRepository {
     override fun getAutoBackupEnabled(): Flow<Boolean> = flowOf(false)
 
     override suspend fun setAutoBackupEnabled(enabled: Boolean) {}
+
+    private var tagUsageOrder: List<Int> = emptyList()
+    private var repeatCycleUsageOrder: List<Int> = emptyList()
+
+    override suspend fun getTagUsageOrder(): List<Int> = tagUsageOrder
+
+    override suspend fun recordTagUsage(tagId: Int) {
+        tagUsageOrder = listOf(tagId) + tagUsageOrder.filter { it != tagId }
+    }
+
+    override suspend fun getRepeatCycleUsageOrder(): List<Int> = repeatCycleUsageOrder
+
+    override suspend fun recordRepeatCycleUsage(cycleId: Int) {
+        repeatCycleUsageOrder = listOf(cycleId) + repeatCycleUsageOrder.filter { it != cycleId }
+    }
 }

--- a/feature/home/src/test/java/com/tgyuu/home/graph/addtodo/AddTodoViewModelUsageSortTest.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/addtodo/AddTodoViewModelUsageSortTest.kt
@@ -1,0 +1,103 @@
+package com.tgyuu.home.graph.addtodo
+
+import androidx.lifecycle.SavedStateHandle
+import com.tgyuu.analytics.NoOpAnalyticsHelper
+import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.ui.resource.ResourceProvider
+import com.tgyuu.home.fake.FakeConfigRepository
+import com.tgyuu.home.fake.FakeTodoRepository
+import com.tgyuu.navigation.NavigationBus
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddTodoViewModelUsageSortTest {
+    private lateinit var todoRepository: FakeTodoRepository
+    private lateinit var configRepository: FakeConfigRepository
+    private lateinit var eventBus: EventBus
+    private lateinit var navigationBus: NavigationBus
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        todoRepository = FakeTodoRepository()
+        configRepository = FakeConfigRepository()
+        eventBus = EventBus()
+        navigationBus = NavigationBus()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): AddTodoViewModel = AddTodoViewModel(
+        todoRepository = todoRepository,
+        configRepository = configRepository,
+        eventBus = eventBus,
+        navigationBus = navigationBus,
+        alarmScheduler = mockk(relaxed = true),
+        analyticsHelper = NoOpAnalyticsHelper(),
+        resourceProvider = object : ResourceProvider {
+            override fun getString(resId: Int): String = ""
+            override fun getString(resId: Int, vararg formatArgs: Any): String = ""
+        },
+        savedStateHandle = SavedStateHandle(mapOf("selectedDate" to "2024-01-01")),
+    )
+
+    @Test
+    fun `반복 주기 목록은 최근 사용 순으로 정렬된다`() = runTest {
+        // given: -4, -2 순으로 사용 (최근 사용이 -2)
+        configRepository.recordRepeatCycleUsage(-4)
+        configRepository.recordRepeatCycleUsage(-2)
+
+        val viewModel = createViewModel()
+
+        // when
+        viewModel.loadRepeatCycles().join()
+
+        // then: 최근 사용(-2, -4)이 앞으로, 나머지는 기본 순서 유지
+        val ids = viewModel.state.value.repeatCycleList.map { it.id }
+        assertEquals(listOf(-2, -4, -1, -5, -3), ids)
+    }
+
+    @Test
+    fun `사용 이력이 없으면 반복 주기 기본 순서를 유지한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadRepeatCycles().join()
+
+        val ids = viewModel.state.value.repeatCycleList.map { it.id }
+        assertEquals(listOf(-1, -5, -2, -3, -4), ids)
+    }
+
+    @Test
+    fun `태그 목록은 최근 사용 순으로 정렬된다`() = runTest {
+        // given: 태그 3개(id 1,2,3), 사용 순서 3 -> 1 (최근 사용이 1)
+        todoRepository.addTag(name = "T1", color = 0)
+        todoRepository.addTag(name = "T2", color = 0)
+        todoRepository.addTag(name = "T3", color = 0)
+        configRepository.recordTagUsage(3)
+        configRepository.recordTagUsage(1)
+
+        val viewModel = createViewModel()
+
+        // when
+        viewModel.loadTags().join()
+
+        // then: 최근 사용(1, 3)이 앞으로, 나머지(2)는 뒤로
+        val ids = viewModel.state.value.tagList.map { it.id }
+        assertEquals(listOf(1, 3, 2), ids)
+    }
+}

--- a/feature/home/src/test/java/com/tgyuu/home/graph/editdate/EditDateViewModelUsageSortTest.kt
+++ b/feature/home/src/test/java/com/tgyuu/home/graph/editdate/EditDateViewModelUsageSortTest.kt
@@ -1,0 +1,84 @@
+package com.tgyuu.home.graph.editdate
+
+import androidx.lifecycle.SavedStateHandle
+import com.tgyuu.analytics.NoOpAnalyticsHelper
+import com.tgyuu.common.event.EventBus
+import com.tgyuu.common.ui.resource.ResourceProvider
+import com.tgyuu.home.fake.FakeConfigRepository
+import com.tgyuu.home.fake.FakeTodoRepository
+import com.tgyuu.navigation.NavigationBus
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditDateViewModelUsageSortTest {
+    private lateinit var todoRepository: FakeTodoRepository
+    private lateinit var configRepository: FakeConfigRepository
+    private lateinit var eventBus: EventBus
+    private lateinit var navigationBus: NavigationBus
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        todoRepository = FakeTodoRepository()
+        configRepository = FakeConfigRepository()
+        eventBus = EventBus()
+        navigationBus = NavigationBus()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): EditDateViewModel = EditDateViewModel(
+        todoRepository = todoRepository,
+        configRepository = configRepository,
+        eventBus = eventBus,
+        navigationBus = navigationBus,
+        alarmScheduler = mockk(relaxed = true),
+        analyticsHelper = NoOpAnalyticsHelper(),
+        resourceProvider = object : ResourceProvider {
+            override fun getString(resId: Int): String = ""
+            override fun getString(resId: Int, vararg formatArgs: Any): String = ""
+        },
+        savedStateHandle = SavedStateHandle(mapOf("infoId" to 1)),
+    )
+
+    @Test
+    fun `수정 화면 반복 주기 목록도 등록과 동일하게 최근 사용 순으로 정렬된다`() = runTest {
+        // given: -4, -2 순으로 사용 (최근 사용이 -2)
+        configRepository.recordRepeatCycleUsage(-4)
+        configRepository.recordRepeatCycleUsage(-2)
+
+        val viewModel = createViewModel()
+
+        // when
+        viewModel.loadRepeatCycles().join()
+
+        // then: 최근 사용(-2, -4)이 앞으로, 나머지는 기본 순서 유지
+        val ids = viewModel.state.value.repeatCycleList.map { it.id }
+        assertEquals(listOf(-2, -4, -1, -5, -3), ids)
+    }
+
+    @Test
+    fun `수정 화면도 사용 이력이 없으면 반복 주기 기본 순서를 유지한다`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.loadRepeatCycles().join()
+
+        val ids = viewModel.state.value.repeatCycleList.map { it.id }
+        assertEquals(listOf(-1, -5, -2, -3, -4), ids)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## 1. ⭐️ 변경된 내용

일정 추가/수정 시 선택했던 태그와 반복 주기를 기억하고, 최근에 사용한 값이 우선 노출되도록 했어요.

- **사용 이력 저장**: 일정 저장/수정 **완료 시점**에 태그·반복 주기 id를 DataStore(`TAG_USAGE_ORDER` / `REPEAT_CYCLE_USAGE_ORDER`, CSV)에 기록해요. 바텀시트에서 선택만 하고 저장하지 않으면 기록되지 않아요.
- **기본 선택값**: 일정 추가 화면 진입 시 마지막 사용 태그·주기가 기본 선택으로 표시돼요. (기존: 미지정 태그 / "한 번만" 고정)
- **바텀시트 정렬**: 태그·반복 주기 바텀시트 목록을 최근 사용순으로 전체 정렬해요. 이력 없는 항목은 기존 순서를 유지한 채 뒤로 배치돼요. (`UsageSort.kt`)
- **폴백**: 삭제된 태그/주기 id는 무시하고 기존 기본값으로 폴백해요. (`loadRepeatCycle`의 `!!` 대신 `find` 사용)

### 변경 계층
| 계층 | 내용 |
|---|---|
| `core:datastore` | `LocalUserConfigDataSource(+Impl)`에 `tagUsageOrder`/`repeatCycleUsageOrder` + `record*Usage` 추가 |
| `core:domain` / `core:data` | `ConfigRepository(+Impl)`에 조회/기록 API 추가 |
| `feature:home` | `AddTodoViewModel`(초기값 복원 + 목록 정렬 + 저장 시 기록), `EditTodoViewModel`(태그 목록 정렬 + 수정 시 기록), `UsageSort.kt` 신규 |
| 테스트 | `AddTodoViewModelUsageSortTest` 신규(3케이스), Fake 2종 갱신 |

## 2. 🖼️ 스크린샷(선택)

에뮬레이터(Pixel 9a) 검증: "Day 60 주기"로 일정 저장 후 재진입하면 반복 주기 바텀시트에서 해당 주기가 **맨 위 + 체크** 상태로 표시돼요.

```
loadRepeatCycles usageOrder=[-4] sortedIds=[-4, -1, -5, -2, -3]
```

## 3. 💡 알게된 부분

- `EbbingBottomSheetState`가 `BottomSheetContent`(@Composable 람다)를 그대로 렌더하므로 ViewModel state만 정렬하면 바텀시트가 반응형으로 재정렬돼요.
- 검증 중 `adb install -r`이 실행 중인 앱에 새 코드를 반영하지 못해 옛 APK로 테스트되는 문제가 있었어요. uninstall 후 재설치로 해결. (한동안 "정렬이 안 된다"고 보였던 원인)

## 4. 📌 이 부분은 꼭 봐주세요!

- **기록 시점**: 바텀시트 Apply(선택)가 아니라 **일정 저장/수정 완료** 시에만 이력이 갱신돼요. 의도된 스펙이에요.
- EditTodo에는 반복 주기 변경 UI가 없어서 태그만 기록해요.
- 사용 이력은 로컬 전용(백업/동기화 대상 아님)이에요. 동기화 범위에 포함해야 할지 의견 부탁드려요.
- `:app` 유닛테스트 컴파일 실패(`FakeSyncRepository.restoreByDeviceId` 미구현)는 develop 기존 이슈로 이 PR과 무관해요.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 할 일 추가·편집 화면에서 태그와 반복 주기가 최근 사용 순서로 표시됩니다.
  * 최근 사용한 태그와 반복 주기가 다음 작성 시 기본 선택값으로 반영됩니다.
  * 선택한 태그와 반복 주기의 사용 이력이 자동으로 저장됩니다.
  * 사용 이력이 없는 항목은 기존 순서를 유지합니다.
  * 태그나 반복 주기를 삭제하거나 전체 데이터를 초기화하면 관련 사용 이력도 정리됩니다.

* **테스트**
  * 최근 사용 순서 정렬과 사용 이력 초기화를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->